### PR TITLE
adds ability to facet on nested fields other than x.name

### DIFF
--- a/app/services/search_item_req.rb
+++ b/app/services/search_item_req.rb
@@ -97,7 +97,7 @@ class SearchItemReq
           interval = "day"
         end
         formatted = interval == "year" ? "yyyy" : "yyyy-MM-dd"
-        histogram = {
+        aggs[f] = {
           "date_histogram" => {
             "field" => field,
             "interval" => interval,
@@ -106,7 +106,6 @@ class SearchItemReq
             "order" => { f_type => dir },
           }
         }
-        aggs[f] = histogram
       # if nested, has extra syntax
       elsif f.include?(".")
         path = f.split(".").first
@@ -115,7 +114,7 @@ class SearchItemReq
             "path" => path
           },
           "aggs" => {
-            "name" => {
+            f => {
               "terms" => {
                 "field" => f,
                 "order" => { type => dir },

--- a/app/services/search_item_res.rb
+++ b/app/services/search_item_res.rb
@@ -50,9 +50,7 @@ class SearchItemRes
         if info.has_key?("buckets")
           buckets = info["buckets"]
         else
-          # get second half of field name
-          nested_field = field.split(".").last
-          buckets = info.dig(nested_field, "buckets")
+          buckets = info.dig(field, "buckets")
         end
         if buckets
           buckets.each do |b|

--- a/test/fixtures/es_response.json
+++ b/test/fixtures/es_response.json
@@ -1,5 +1,5 @@
 {
-  "took" : 13,
+  "took" : 10,
   "timed_out" : false,
   "_shards" : {
     "total" : 5,
@@ -7,1713 +7,1886 @@
     "failed" : 0
   },
   "hits" : {
-    "total" : 59,
-    "max_score" : 5.1007433,
+    "total" : 50,
+    "max_score" : 5.046675,
     "hits" : [
       {
         "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00475",
-        "_score" : 5.1007433,
+        "_type" : "cather",
+        "_id" : "cat.let1873",
+        "_score" : 5.046675,
         "_source" : {
-          "identifier" : "wfc.css00475",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
+          "identifier" : "cat.let1873",
+          "category" : "Writings",
+          "subcategory" : "Letters",
           "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, april 28, 189[6]",
-          "title" : "Letter from William F. Cody to George T. Beck, April 28, 189[6]",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to elsie cather, april 26 [1908]",
+          "title" : "Willa Cather to Elsie Cather, April 26 [1908]",
           "description" : null,
           "format" : "letter",
           "language" : null,
           "medium" : "letter",
-          "date_display" : "April 28, 1896",
-          "date" : "1896-04-28",
-          "date_not_before" : "1896-04-28",
-          "date_not_after" : "1896-04-28",
+          "date_display" : "April 26, 1908",
+          "date" : "1908-04-26",
+          "date_not_before" : "1908-04-26",
+          "date_not_after" : "1908-04-26",
           "rights_uri" : null,
-          "publisher" : "",
+          "publisher" : "University of Nebraska–Lincoln",
           "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill Letters to George T. Beck (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943; Hayden, Charles E., 1866-1938; Rumsey, Bronson, II, 1854-1946",
+          "source" : "University of Nebraska-Lincoln Libraries, Archives and Special Collections, Lincoln, NE",
+          "rights_holder" : "University of Nebraska-Lincoln Libraries, Archives and Special Collections, Lincoln, NE",
           "person" : [
             {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
+              "name" : "Cather, Elsie",
+              "id" : "0187",
+              "role" : "addressee"
             },
             {
-              "role" : null,
-              "name" : "Hayden, Charles E., 1866-1938",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Rumsey, Bronson, II, 1854-1946",
-              "id" : ""
+              "name" : "Cather, Elsie",
+              "id" : "0187"
             }
           ],
           "contributor" : [
             {
-              "name" : "Weakly, Laura K.",
-              "id" : null,
-              "role" : null
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
             },
             {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
             },
             {
-              "name" : "Houze, Lynn",
-              "id" : "lh",
-              "role" : null
-            },
-            {
-              "name" : "Johnston, Jeremy",
-              "id" : "jj",
-              "role" : null
-            },
-            {
-              "name" : "Clark, Linda",
-              "id" : "lc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
             }
           ],
           "creator" : [
             {
-              "name" : "Cody, William Frederick, 1846-1917"
+              "name" : "Willa Cather"
             }
           ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Cather, Elsie; Cather, Elsie",
           "keywords" : [ ],
           "places" : [
-            "Shoshone Irrigation District (Wyo.)"
+            "Naples, Campania, Italy",
+            "Red Cloud, Nebraska, United States"
           ],
           "works" : [ ],
-          "annotations" : null,
-          "text" : "   Buffalo Bill's Wild West and Congress of Rough Riders.of the World.Col. W. F. Cody. (Buffalo Bill), President.Nate Salsbury. Vice-President & Manager.John M. Burke. General Manager.Albert E. Sheible, Business Manager.Jule Keen, Treasurer. Clarksburg W. Va1 Apr 28th2 My Dear George Yours from Billings to hand. I fs have just sent your letter on to Salsbury and for him to send on the 5000. but I hardly know how we are going to raise the rest to pay off 10th of May pay roll— and no water to Sulphur creek3 George things are being done there badly or the water would be in Sulphur Creek now. The Management4 is ceartainlycertainly Bad there is a great leak some place. I have no idea what the 10th of May pay roll will amount to— I can hear nothing direct from any one— I wrote Flood5 & Hayden to let me know but they have not— I have about given up all hope of water ever getting to Sulphur Creek— or whether the Graders ever got there— And yet allthoughalthough Rumsey Says this is not a one man company I have to personalypersonally endorse for everything and I get the blame for everything— and  no one will even tell me whats going on—  I am most heartlyheartily discouraged— Cody   "
+          "annotations" : "A studio portrait of Elsie Margaret Cather Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Cather, Elsie Margaret (1890-1964) (“Bobbie”). Cather’s sister. Born in Red Cloud, NE, shortly before Willa Cather graduated from high school, Elsie attended the University of Nebraska in Lincoln from 1908 to 1910, before transferring to Smith College, in Northampton, MA, from which she graduated with an A.B. in English and Latin in 1912. She undertook graduate study at the University of Nebraska in 1914 and in 1916 received her A.M. with a major in philosophy and a minor in English. At both the undergraduate and the graduate level at Nebraska, she studied under Louise Pound. She began a career in high school teaching in 1912, when she took a position in Lander, WY, where her brother Roscoe then lived with his family. She also taught in Albuquerque, NM; Corning, IA; Cleveland, OH; and briefly Red Cloud, when illness in the family brought her home. Her longest tenure as a teacher was at Lincoln (NE) High School, where she began teaching in 1920, with Olivia Pound and Mariel Gere as colleagues. Willa Cather's expectation that Elsie be responsible for aging family and friends and for legal affairs after their parents' deaths sometimes brought the sisters into conflict. Elsie Cather retired from Lincoln High School in 1942. She died in Lincoln.A studio portrait of Elsie Margaret Cather Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Cather, Elsie Margaret (1890-1964) (“Bobbie”). Cather’s sister. Born in Red Cloud, NE, shortly before Willa Cather graduated from high school, Elsie attended the University of Nebraska in Lincoln from 1908 to 1910, before transferring to Smith College, in Northampton, MA, from which she graduated with an A.B. in English and Latin in 1912. She undertook graduate study at the University of Nebraska in 1914 and in 1916 received her A.M. with a major in philosophy and a minor in English. At both the undergraduate and the graduate level at Nebraska, she studied under Louise Pound. She began a career in high school teaching in 1912, when she took a position in Lander, WY, where her brother Roscoe then lived with his family. She also taught in Albuquerque, NM; Corning, IA; Cleveland, OH; and briefly Red Cloud, when illness in the family brought her home. Her longest tenure as a teacher was at Lincoln (NE) High School, where she began teaching in 1920, with Olivia Pound and Mariel Gere as colleagues. Willa Cather's expectation that Elsie be responsible for aging family and friends and for legal affairs after their parents' deaths sometimes brought the sisters into conflict. Elsie Cather retired from Lincoln High School in 1942. She died in Lincoln.",
+          "text" : "View of the water from S. Lucia street in Naples. Napoli - Strada S. Lucia 35 Ediz Artistica RICTER&C: NAPOLI. Propr Riserv. April 26 Dear Elsie- Please send your letters to the New York office. They will be forwarded to me.—The color in this card is not one bit exaggerated. The sea is even more purple. There are trees and little gardens on all the houcetops[housetops]. W.S.C CARTOLINA POSTALE CARTE POSTALE — POSTKARTE Miss Elsie Margaret Cather Red Cloud Nebraska United States of America. NAPOLI"
         },
         "highlight" : {
           "text" : [
-            " hardly know how we are going to raise the rest to pay off 10th of May pay roll— and no <em>water</em> to",
-            " Sulphur creek3 George things are being done there badly or the <em>water</em> would be in Sulphur Creek now. The",
-            " to let me know but they have not— I have about given up all hope of <em>water</em> ever getting to Sulphur"
+            "View of the <em>water</em> from S. Lucia street in Naples. Napoli - Strada S. Lucia 35 Ediz Artistica RICTER"
           ]
         }
       },
       {
         "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00531",
-        "_score" : 4.761321,
+        "_type" : "cather",
+        "_id" : "cat.let2250",
+        "_score" : 3.7249577,
         "_source" : {
-          "identifier" : "wfc.css00531",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
+          "identifier" : "cat.let2250",
+          "category" : "Writings",
+          "subcategory" : "Letters",
           "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, april 23, 1899",
-          "title" : "Letter from William F. Cody to George T. Beck, April 23, 1899",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to meta schaper cather, [august 16, 1916]",
+          "title" : "Willa Cather to Meta Schaper Cather, [August 16, 1916]",
           "description" : null,
           "format" : "letter",
           "language" : null,
           "medium" : "letter",
-          "date_display" : "April 23, 1899",
-          "date" : "1899-04-23",
-          "date_not_before" : "1899-04-23",
-          "date_not_after" : "1899-04-23",
+          "date_display" : "August 16, 1916",
+          "date" : "1916-08-16",
+          "date_not_before" : "1916-08-16",
+          "date_not_after" : "1916-08-16",
           "rights_uri" : null,
-          "publisher" : "",
+          "publisher" : "University of Nebraska–Lincoln",
           "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill: Letters to George T. Beck, 1895-1910 (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
+          "source" : "University of Nebraska-Lincoln, Archives and Special Collections, Lincoln, NE",
+          "rights_holder" : "University of Nebraska-Lincoln, Archives and Special Collections, Lincoln, NE",
           "person" : [
             {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
+              "name" : "Cather, Meta Schaper",
+              "id" : "0199",
+              "role" : "addressee"
             },
             {
-              "name" : "Christianson, Johnston, Houze, Clark",
-              "id" : "bbhc",
-              "role" : null
+              "name" : "Cather, Roscoe",
+              "id" : "0200"
             },
             {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
+              "name" : "Cather, Meta Schaper",
+              "id" : "0199"
             },
             {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [ ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   Buffalo Bill's Wild West Linchburg Va1 Apr- 23d 99 Dear Beck Yours 15th I do hope you will push the work and get the water down. You should have commenced sooner. I told you I would send the 1000- did I ever fail yet. When we get a rail road which will be in side of three years— and our town numbers thousands and land worth $100 an acre— then I wont have such hard work getting my colleagues to put up— The B.M.2 will build to us sure— Our settlers should plant every acre possible. They will get their own prices next winter. Now is the time to farm before the rail road gets there— Write me fully. When will you have water in Cody? Yours— Cody  "
-        },
-        "highlight" : {
-          "text" : [
-            " the work and get the <em>water</em> down. You should have commenced sooner. I told you I would send the 1000",
-            " get their own prices next winter. Now is the time to farm before the rail road gets there— Write me fully. When will you have <em>water</em> in Cody? Yours— Cody  "
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00456",
-        "_score" : 4.680297,
-        "_source" : {
-          "identifier" : "wfc.css00456",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, october 6, 1895",
-          "title" : "Letter from William F. Cody to George T. Beck, October 6, 1895",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "October 6, 1890",
-          "date" : "1890-10-06",
-          "date_not_before" : "1890-10-06",
-          "date_not_after" : "1890-10-06",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill Letters to George T. Beck (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943; Foote, Robert, 1834-1916; Peake, John A.; Wetmore, Helen Cody, 1850-1911",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
+              "name" : "Brockway, Virginia Cather",
+              "id" : "0201"
             },
             {
-              "role" : null,
-              "name" : "Wetmore, Helen Cody, 1850-1911",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Peake, John A.",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Foote, Robert, 1834-1916",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : null,
-              "role" : null
-            },
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Clark, Linda",
-              "id" : "lc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [
-            "Cotton States Exposition (1895 : Atlanta, Ga.)"
-          ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "    The Buffalo Bill Wild West and Congress of Rough Riders of the World. Col. W. F. Cody (Buffalo Bill), President.Nate Salsbury, Vice-Pres't and Manager.John M. Burke, . . . General Manager.Albert E. Scheible, . . . Business Manager.Jule Keen, . . . Treasurer.  Wilmington N. C.1 Oct— 6th 95 My. Dear— Beck.  I must give German. Colony2 managers an answer. If you have the funds how many acres can you irrigate or have ready to irrigate for next year. if you finish to Sulphur3 this fall & cantcan't work through winter can you commence early enough next spring on the ditch. and finish up enough to open up some of the country East. So that farmers can raise a crop next summer? If so about how many acres can you have ready to irrigate. Will the frost be out of ground so you can build ditch in April? if so you will have April & May to build ditch. giving farmers water first of June. Knowing the land as you do how many acres can you get water on by first of June. I want to begin to Advertise at Atlanta. Get some one to write it up get some photos taken. Send it at once to my  paper. Duluth Press.4 And tell my editor J. H. Peake to get it out at once and send it to me. Lets begin to advertise Before Foote5 knocks us out. Hurry up George. And have it written up & photos taken— Bill  "
-        },
-        "highlight" : {
-          "text" : [
-            " April? if so you will have April & May to build ditch. giving farmers <em>water</em> first of June. Knowing",
-            " the land as you do how many acres can you get <em>water</em> on by first of June. I want to begin to Advertise"
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00525",
-        "_score" : 4.650588,
-        "_source" : {
-          "identifier" : "wfc.css00525",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, july 20, 1898",
-          "title" : "Letter from William F. Cody to George T. Beck, July 20, 1898",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "July 20, 1898",
-          "date" : "1898-07-20",
-          "date_not_before" : "1898-07-20",
-          "date_not_after" : "1898-07-20",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill Letters to George T. Beck (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Houze, Lynn",
-              "id" : "lh",
-              "role" : null
-            },
-            {
-              "name" : "Johnston, Jeremy",
-              "id" : "jj",
-              "role" : null
-            },
-            {
-              "name" : "Clark, Linda",
-              "id" : "lc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [ ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   Buffalo Bill's Wild West Big. Rapids. Mich1 July. 20th 98 My Dear Beck— Your letter of the 13th sent Manistee2 forwarded here. ItsIt's too bad about the Dam washing out, as Gen. Manager. you should bar cloud bursts. Well it cantcan't be helped. And you done perfectly right In repairing the damage and getting water to the farms and Cody. As soon as possible. I hope you have pushed the work. I know the importance of getting the water quick. I will send Alger $200. and will ask Salsbury to do the same. Also the other stock holders3. Keep me posted—  Yours hastlyhastily W. F. Cody  P. S. I fear the mill will have to hold over annotheranother year— W. F. C  "
-        },
-        "highlight" : {
-          "text" : [
-            " damage and getting <em>water</em> to the farms and Cody. As soon as possible. I hope you have pushed the work. I",
-            " know the importance of getting the <em>water</em> quick. I will send Alger $200. and will ask Salsbury to do"
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00537",
-        "_score" : 4.650588,
-        "_source" : {
-          "identifier" : "wfc.css00537",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, september 6, [1899]",
-          "title" : "Letter from William F. Cody to George T. Beck, September 6, [1899]",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "September 6, 1899",
-          "date" : "1899-09-06",
-          "date_not_before" : "1899-09-06",
-          "date_not_after" : "1899-09-06",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill: Letters to George T. Beck, 1895-1910 (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Christianson, Johnston, Houze, Clark",
-              "id" : "bbhc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [ ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   Buffalo Bill's Wild West Abberdeen- So Dak1 Sep 62 Dear Beck Your favor of Aug 31 pleases me— Yes we must surely have a directors3 meeting and see if we cantcan't get a moovemove on them— I wish you would be prepared with some estimates and suggestions, George keep the water coming till it freezes up— I wrote Schwoob Cody Trading Co. Should build a big cistern— or the Town5 should chip in and build a big one— See if you cantcan't get them at it— Keep me posted about the hotel6. I hope it will go through. Yours Cody   George— try and fill some place with water so there will be an ice pond. we must have ice next summer let me know if you can do this—  "
-        },
-        "highlight" : {
-          "text" : [
-            " you would be prepared with some estimates and suggestions, George keep the <em>water</em> coming till it",
-            " will go through. Yours Cody   George— try and fill some place with <em>water</em> so there will be an ice pond"
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00479",
-        "_score" : 4.4795046,
-        "_source" : {
-          "identifier" : "wfc.css00479",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, september 4, 1896",
-          "title" : "Letter from William F. Cody to George T. Beck, September 4, 1896",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "September 4, 1896",
-          "date" : "1896-09-04",
-          "date_not_before" : "1896-09-04",
-          "date_not_after" : "1896-09-04",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill Letters to George T. Beck (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943; Bleistein, George, 1861-1918; Rumsey, Bronson, II, 1854-1946; Stokes, Edward S., 1841-1901",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Bleistein, George, 1861-1918",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Rumsey, Bronson, II, 1854-1946",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Stokes, Edward S., 1841-1901",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : null,
-              "role" : null
-            },
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Houze, Lynn",
-              "id" : "lh",
-              "role" : null
-            },
-            {
-              "name" : "Johnston, Jeremy",
-              "id" : "jj",
-              "role" : null
-            },
-            {
-              "name" : "Clark, Linda",
-              "id" : "lc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [ ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   Buffalo Bill's Wild West and Congress of Rough Riders.of the World.Col. W. F. Cody. (Buffalo Bill), President.Nate Salsbury. Vice-President & Manager.John M. Burke. General Manager.Albert E. Sheible, Business Manager.Jule Keen, Treasurer.   Stevenspoint Wis1 Sep 4th2 Dear George Was glad to receive your favor of Aug 31st— I want to ask you two questions first. In your report of Aug 28th you say the Canal is at last opened up to the completed mile and water will soon be at the City.3 When do you expect to have water down to the Town? 2d Have you written the Buffalo people4 urgeingurging the necessity of money to meet bills? If so have they answered? I will And have you sent Stokes5 his stock? I will be glad to know how much the Co. owes. Are you going to order a stock of goods—  Col  "
-        },
-        "highlight" : {
-          "text" : [
-            " say the Canal is at last opened up to the completed mile and <em>water</em> will soon be at the City.3 When do",
-            " you expect to have <em>water</em> down to the Town? 2d Have you written the Buffalo people4 urgeingurging the"
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00467",
-        "_score" : 4.4265456,
-        "_source" : {
-          "identifier" : "wfc.css00467",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, march 26, 189[6]",
-          "title" : "Letter from William F. Cody to George T. Beck, March 26, 189[6]",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "March 26, 1896",
-          "date" : "1896-03-26",
-          "date_not_before" : "1896-03-26",
-          "date_not_after" : "1896-03-26",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill Letters to George T. Beck (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943; Mead, Elwood, 1858-1936; Rumsey, Bronson, II, 1854-1946; Salsbury, Nathan, 1846-1902",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Salsbury, Nathan, 1846-1902",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Rumsey, Bronson, II, 1854-1946",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Mead, Elwood, 1858-1936",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : null,
-              "role" : null
-            },
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Houze, Lynn",
-              "id" : "lh",
-              "role" : null
-            },
-            {
-              "name" : "Johnston, Jeremy",
-              "id" : "jj",
-              "role" : null
-            },
-            {
-              "name" : "Clark, Linda",
-              "id" : "lc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [
-            "Black America"
-          ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   Col. W. F. Cody, (Buffalo Bill) President.Nate Salsbury, Vice Prest & Manager.John M. Burke, General Manager.Albert E. Sheible, Business Manager.Jule Keen, Treasurer.Buffalo Bill's Wild West and Congress of Rough Riders of the World.The Largest Arenic Exhibition known in History.Col. W. F. Cody Nate SalsburySeason of 1895.Staff of Jas. A. Bailey, Director of Tour.J. T. McCaddon, Superintendent.W. H. Gardner, Gen'l Agent.M. Coyle, R.R. and Excursion Manager.George O. Starr, Press Agent.C. R. Hutchinson, Treasurer.New York Office, No. 106 W. 37th St.  Mar 26 18951 My Dear Beck  Went to Cheyenne2 and fixed up a water bond3 which I hope will prooveprove allright. Am sweating blood trying to get President4 to sign contract. have every assurance he will do it this week. State contract is ready soon as President signs. I have Burke in Washington And have sent fifty telegrams there— I appreciate the fact but I dontdon't presume annother member of this Co does that there is several things that have to be rushed. Have you spoken to Rumsey how short we are for funds— is his Brother5 coming in? Or are you checking out and giveinggiving no one any warning until checks go to protest? I have no idea what your expenses are this month. Why dontdon't you ask some one to write me? Some one from that end should keep the  Col. W. F. Cody, (Buffalo Bill) President.Nate Salsbury, Vice Prest & Manager.John M. Burke, General Manager.Albert E. Sheible, Business Manager.Jule Keen, Treasurer.Buffalo Bill's Wild West and Congress of Rough Riders of the World.The Largest Arenic Exhibition known in History.Col. W. F. Cody Nate SalsburySeason of 1895.Staff of Jas. A. Bailey, Director of Tour.J. T. McCaddon, Superintendent.W. H. Gardner, Gen'l Agent.M. Coyle, R.R. and Excursion Manager.George O. Starr, Press Agent.C. R. Hutchinson, Treasurer.New York Office, No. 106 W. 37th St.________ 1895 different members of the Co. posted of whatswhat's being done— then when we call on them for money there would not be such a howl of where the money has gone— George— you see I nor no one can form an idea how long itsit's going to take to get through or arroundaround those red bluffs6 where you take the water out of sulphur creek7— or the cost— So I cantcan't arrange for any more settlers as I dontdon't know if there can be water put on it this year. Mead will be up in a few days to help you out— Then if a man could be found who would write. Yours—  Cody    Omaha- 30th-31-1st Chicago 2-3d 4th Washington 5 New. York 6-7-8-9- After that Philadelphia till Apr 258   Col. W. F. Cody, (Buffalo Bill) President.Nate Salsbury, Vice Prest & Manager.John M. Burke, General Manager.Albert E. Sheible, Business Manager.Jule Keen, Treasurer.Buffalo Bill's Wild West and Congress of Rough Riders of the World.The Largest Arenic Exhibition known in History.Col. W. F. Cody Nate SalsburySeason of 1895.Staff of Jas. A. Bailey, Director of Tour.J. T. McCaddon, Superintendent.W. H. Gardner, Gen'l Agent.M. Coyle, R.R. and Excursion Manager.George O. Starr, Press Agent.C. R. Hutchinson, Treasurer.New York Office, No. 106 W. 37th St.________ 1895 PS. George. I wrote you to Sheridan that if I had the ready cash I would send you 3000 at once—I am putting every dollar I make with this show into Black America9 As Salsbury is still dangerously sick. cantcan't sign a check so I have to put up. But as soon as I can I will help you out—   Yours— Bill   "
-        },
-        "highlight" : {
-          "text" : [
-            " Cheyenne2 and fixed up a <em>water</em> bond3 which I hope will prooveprove allright. Am sweating blood trying to",
-            " <em>water</em> out of sulphur creek7— or the cost— So I cantcan't arrange for any more settlers as I",
-            " dontdon't know if there can be <em>water</em> put on it this year. Mead will be up in a few days to help you out"
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00516",
-        "_score" : 4.4134736,
-        "_source" : {
-          "identifier" : "wfc.css00516",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, april 19, 1897",
-          "title" : "Letter from William F. Cody to George T. Beck, April 19, 1897",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "April 19, 1897",
-          "date" : "1897-04-19",
-          "date_not_before" : "1897-04-19",
-          "date_not_after" : "1897-04-19",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill Letters to George T. Beck (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Houze, Lynn",
-              "id" : "lh",
-              "role" : null
-            },
-            {
-              "name" : "Johnston, Jeremy",
-              "id" : "jj",
-              "role" : null
-            },
-            {
-              "name" : "Clark, Linda",
-              "id" : "lc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [ ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   April 19-1897—1 The monied men of our Co. want to know what you are doing & if you are going to get water to the town2 & below. They say they are tired of such management and if you can't do the work they want to know it and at once. George you told me you would be at Cody to commence work by the 1st of April. God only know where you are and if you will ever get to Cody and if you will get to work when you do get there. If water aintain't down to town early we are ruined. George if you don't try to do something this dam ditch will drive me crazy. Why won't you for once get down to work & see that the men and or you work. For Gods sake do something. I can't stand the company off with fairy tales any longer— Yours Cody  "
-        },
-        "highlight" : {
-          "text" : [
-            " get <em>water</em> to the town2 & below. They say they are tired of such management and if you can't do the",
-            " work when you do get there. If <em>water</em> aintain't down to town early we are ruined. George if you don't"
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00363",
-        "_score" : 4.401066,
-        "_source" : {
-          "identifier" : "wfc.css00363",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from c. h. morrill to c. e. perkins, november 22, 1899",
-          "title" : "Letter from C. H. Morrill to C. E. Perkins, November 22, 1899",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "November 22, 1899",
-          "date" : "1899-11-22",
-          "date_not_before" : "1899-11-22",
-          "date_not_after" : "1899-11-22",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "Newberry Library, CB&Q collection, 33, 1890, 6.8, Big Horn Basin",
-          "creator_sort" : "Morrill, Charles H., 1842 - 1928",
-          "people" : "",
-          "person" : [
-            {
-              "role" : null,
               "name" : "",
-              "id" : ""
+              "id" : "psn"
+            },
+            {
+              "name" : "Cather, Charles Douglass 'Douglass'",
+              "id" : "0182"
             }
           ],
           "contributor" : [
             {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
             },
             {
-              "name" : "Tiedje, Michelle",
-              "id" : null,
-              "role" : null
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
             }
           ],
           "creator" : [
             {
-              "name" : "Morrill, Charles H., 1842 - 1928"
+              "name" : "Willa Cather"
             }
           ],
-          "keywords" : [ ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   C. H. Morrill, President. A.B. Minor, Sec'y and Treasurer. Office of the Lincoln Land Company, Rooms 20 to 23, Burr Block, Lincoln, Neb. Quotations of prices are subject to change without notice. Lincoln, Neb. Nov. 22, 1899. My dear Mr. Perkins,—  While I was at Cheyenne, I made some investigation in regard to irrigation schemes in Wyoming and particularly in the big horn basin. I presume you know that under the Cary actCarey Act, the different states in which arid lands are located had the privilege of selecting one million acres to be used as an inducement to further irrigation schemes. Wyoming has selected nearly all of its land and at the present time have commissioners selecting the balance. The Cary actCarey Act expires in 1904. Any states that have not selected at that time will be left out. In Wyoming there has been five big irrigation schemes, including Cody's and the Burlington (by Wiley of Omaha). Land has been segregated to each of these schemes, but they have all been thrown up with the exception of Cody's and the Burlington. Under the Cary actCarey Act the settlers must produce certificate from the Water Company that they have a paid up water right sufficient to irrigate the land. They can then enter the land from the state by paying 25 cents per acre. At the end of three years they must submit proof that they have at least 20 acres under irrigation. If so they get a deed for the land making in all $10.00 to the Water Company and 50 cents to the state. The Burlington (Wiley's) has 30,000 acres of land segregated. On this land, as shown by the records in Cheyenne, there is just 20 settlers. Several of the settlers have already filed complaints that there is not a sufficient amount of water and that they have determined to throw up their claims. The State authorities informed me that they would investigate the condition of the Burlington ditch this winter. Under Cody's scheme there is probably not more 10 settlers. I asked the Commissioner if he considered the Cary actCarey Act a good piece of legislation. He said up to the present time it had been a failure. In regard to the probablyprobable success of the Cody scheme, he said it was improbable unless somebody else took hold of it. I also conferred with a gentleman who the state officers designate as their coal expert. I do not think he knows as much about the coal prospects in the big horn basin as I do, but he said that from what information he had he thought there was plenty of coal in the big horn basin, but it was all lignite.  Yours truly, C. H. Morrill  Mr. C. E. Perkins    "
-        },
-        "highlight" : {
-          "text" : [
-            " must produce certificate from the <em>Water</em> Company that they have a paid up <em>water</em> right sufficient to",
-            " they get a deed for the land making in all $10.00 to the <em>Water</em> Company and 50 cents to the state. The",
-            " is not a sufficient amount of <em>water</em> and that they have determined to throw up their claims. The"
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00532",
-        "_score" : 4.389344,
-        "_source" : {
-          "identifier" : "wfc.css00532",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, april 24, 1899",
-          "title" : "Letter from William F. Cody to George T. Beck, April 24, 1899",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "April 24, 1899",
-          "date" : "1899-04-24",
-          "date_not_before" : "1899-04-24",
-          "date_not_after" : "1899-04-24",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill: Letters to George T. Beck, 1895-1910 (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Christianson, Johnston, Houze, Clark",
-              "id" : "bbhc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [ ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   Buffalo Bill's Wild West Lynchburg. Va1 Apr. 24th 99 My Dear Beck Ex Gov. Richards2 says we ought to fix up our affairs so that our Settlers and our selves can proove up. by doing this our company can get in some ready cash. let me hear from you, and when you expect have water runing into Cody. for goodness sakes George rush it a long— Yours Cody  "
-        },
-        "highlight" : {
-          "text" : [
-            " can get in some ready cash. let me hear from you, and when you expect have <em>water</em> runing into Cody"
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00533",
-        "_score" : 4.269311,
-        "_source" : {
-          "identifier" : "wfc.css00533",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, april 30, 1899",
-          "title" : "Letter from William F. Cody to George T. Beck, April 30, 1899",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "April 30, 1899",
-          "date" : "1899-04-30",
-          "date_not_before" : "1899-04-30",
-          "date_not_after" : "1899-04-30",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill: Letters to George T. Beck, 1895-1910 (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Christianson, Johnston, Houze, Clark",
-              "id" : "bbhc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [ ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   Buffalo Bill's Wild West Nashville Tenn1 Apr 30th 99 My Dear Beck Please let me know how you are getting on with ditch. When do you expect to have water to town2. How are you makeingmaking it with Darrah? Say if the rest of the Company dontdon't put up to pay interest on Hearst loan3— What had best be done? Love to Bettie4 Your friend Cody  "
-        },
-        "highlight" : {
-          "text" : [
-            " getting on with ditch. When do you expect to have <em>water</em> to town2. How are you makeingmaking it with"
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00530",
-        "_score" : 4.237417,
-        "_source" : {
-          "identifier" : "wfc.css00530",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, march 10, 1899",
-          "title" : "Letter from William F. Cody to George T. Beck, March 10, 1899",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "March 10, 1899",
-          "date" : "1899-03-10",
-          "date_not_before" : "1899-03-10",
-          "date_not_after" : "1899-03-10",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill: Letters to George T. Beck, 1895-1910 (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Christianson, Johnston, Houze, Clark",
-              "id" : "bbhc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [ ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   Apartments.European Plan.American Plan.Auditorium HotelBreslin & SouthgateR. H. Southgate, Manager. Chicago,  Mar. 10 1899 My Dear Beck Yours recd Buffalo parties1 dont seem to feel like putting up Any more money. I have written them about the bridge2. I dont beleivebelieve Salsbury will put up a dollar- for he Says the money is so badly handeledhandled. If I ask him to put up with me to bring water to Cody & flats3. He will say who is to take charge of work- You know George that heretofore no money has been properly used  Apartments.European Plan.American Plan.Auditorium HotelBreslin & SouthgateR. H. Southgate, Manager. Chicago, __________189___  that is the men hired to do work have not been managed right. No boss— no one to lay their work out for them or stay with them to see that they do an honest days work— That decd canal has been done on a widow womans way of getting work out of men. If you are to take charge of it which no one could do better that is if you would stay with the men and see that their work is lay out  Apartments.European Plan.American Plan.Auditorium HotelBreslin & SouthgateR. H. Southgate, Manager. Chicago, __________189___  their work— be with them in the mornings and see that they work go over the ditch your self- and see what it needs &c- If you will write Salsbury that you will do this, I will guarnteeguarantee that the $1000 be placed to your credit at once If youg will get down to business and write us that you will be on the job the money will be at Carbon Co Bank4- But we wontwon't stand any more slip-  Apartments.European Plan.American Plan.Auditorium HotelBreslin & SouthgateR. H. Southgate, Manager. Chicago, __________189___  shod way of haveinghaving our money wasted. I should think that you would want water for your own farm and would be willing to use every energy to get it there. We have to work hard for our money and I dontdon't blame our stock holders refuseingrefusing to put up. When the men who handle it wont work— Very truly yours W. F. Cody  "
-        },
-        "highlight" : {
-          "text" : [
-            " <em>water</em> to Cody & flats3. He will say who is to take charge of work- You know George that heretofore",
-            " of haveinghaving our money wasted. I should think that you would want <em>water</em> for your own farm and"
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00527",
-        "_score" : 4.134582,
-        "_source" : {
-          "identifier" : "wfc.css00527",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, august 12, 1898",
-          "title" : "Letter from William F. Cody to George T. Beck, August 12, 1898",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "August 12, 1898",
-          "date" : "1898-08-12",
-          "date_not_before" : "1898-08-12",
-          "date_not_after" : "1898-08-12",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill Letters to George T. Beck (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Houze, Lynn",
-              "id" : "lh",
-              "role" : null
-            },
-            {
-              "name" : "Johnston, Jeremy",
-              "id" : "jj",
-              "role" : null
-            },
-            {
-              "name" : "Clark, Linda",
-              "id" : "lc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [ ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   Buffalo Bill's Wild West and Congress of Rough Riders.of the World.Col. W. F. Cody. (Buffalo Bill), President.Nate Salsbury. Vice-President & Manager.John M. Burke. General Manager.Albert E. Sheible, Business Manager.Jule Keen, Treasurer.  Dubuque1 Aug 122 My Dear Beck Will you please hire some one charge Same to me. to tell me if the water has reached Cody & farms— W. F. Cody  "
-        },
-        "highlight" : {
-          "text" : [
-            " one charge Same to me. to tell me if the <em>water</em> has reached Cody & farms— W. F. Cody  "
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00503",
-        "_score" : 4.1166434,
-        "_source" : {
-          "identifier" : "wfc.css00503",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, september 7, 189[6]",
-          "title" : "Letter from William F. Cody to George T. Beck, September 7, 189[6]",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "September 7, 1896",
-          "date" : "1896-09-07",
-          "date_not_before" : "1896-09-07",
-          "date_not_after" : "1896-09-07",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill Letters to George T. Beck (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Houze, Lynn",
-              "id" : "lh",
-              "role" : null
-            },
-            {
-              "name" : "Johnston, Jeremy",
-              "id" : "jj",
-              "role" : null
-            },
-            {
-              "name" : "Clark, Linda",
-              "id" : "lc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [ ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   The CameronD. P. Smith, Proprietor.Wilmanns Bros. Litho. Milwaukee.La Crosse, Wis. Sep 7, 189_1 My Dear George I see that women are nameingnaming and runingrunning the Town.2 if so I wontwon't put up annotheranother dollar I dontdon't care a damn whether water ever gets there or not. And how quick all work stops. My interest in the dam town is ended. Col  "
-        },
-        "highlight" : {
-          "text" : [
-            " up annotheranother dollar I dontdon't care a damn whether <em>water</em> ever gets there or not. And how"
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00539",
-        "_score" : 4.0343895,
-        "_source" : {
-          "identifier" : "wfc.css00539",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, august 16, 1900",
-          "title" : "Letter from William F. Cody to George T. Beck, August 16, 1900",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "August 16, 1900",
-          "date" : "1900-08-16",
-          "date_not_before" : "1900-08-16",
-          "date_not_after" : "1900-08-16",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill: Letters to George T. Beck, 1895-1910 (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Christianson, Johnston, Houze, Clark",
-              "id" : "bbhc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
-          "keywords" : [ ],
-          "places" : [ ],
-          "works" : [ ],
-          "annotations" : null,
-          "text" : "   Buffalo Bill's Wild West and Congress of Rough Riders.of the World. Col. W. F. Cody. (Buffalo Bill), President. Nate Salsbury. Vice-President & Manager. John M. Burke. General Manager.Albert E. Sheible, Business Manager.Jule Keen, Treasurer.  Charles City- Ia1 Aug 16th 1900 My- Dear Beck I was pleased to get your letter of the 10th I hope the protest case2 is ended and I trust that we will soon get our patent3. I am sorry you think Mr Martin4 was not friendly to you. I told him on his return that he should have consulted you. he located claims in your name— And I cannot make out why he did not work with you— I will send you the $25— to finish half payments on block 7. is the water still coming down to Town5 & into the reservoir— do try and get all the water you possibly can in the reservoir6— so we can show people this reservoir this winter— My business big.7  Yours Cody  "
-        },
-        "highlight" : {
-          "text" : [
-            " not work with you— I will send you the $25— to finish half payments on block 7. is the <em>water</em> still",
-            " coming down to Town5 & into the reservoir— do try and get all the <em>water</em> you possibly can in the"
-          ]
-        }
-      },
-      {
-        "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00466",
-        "_score" : 3.9922526,
-        "_source" : {
-          "identifier" : "wfc.css00466",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
-          "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, march 26, 1896",
-          "title" : "Letter from William F. Cody to George T. Beck, March 26, 1896",
-          "description" : null,
-          "format" : "letter",
-          "language" : null,
-          "medium" : "letter",
-          "date_display" : "March 26, 1896",
-          "date" : "1896-03-26",
-          "date_not_before" : "1896-03-26",
-          "date_not_after" : "1896-03-26",
-          "rights_uri" : null,
-          "publisher" : "",
-          "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill Letters to George T. Beck (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943; Grouard, Frank, 1850-1905; Mondell, Frank Wheeler, 1860-1939; Nagle, F. A.; Nagle, S. V.; Rumsey, Bronson, II, 1854-1946",
-          "person" : [
-            {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Rumsey, Bronson, II, 1854-1946",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Grouard, Frank, 1850-1905",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Mondell, Frank Wheeler, 1860-1939",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Nagle, F. A.",
-              "id" : ""
-            },
-            {
-              "role" : null,
-              "name" : "Nagle, S. V.",
-              "id" : ""
-            }
-          ],
-          "contributor" : [
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : null,
-              "role" : null
-            },
-            {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
-            },
-            {
-              "name" : "Houze, Lynn",
-              "id" : "lh",
-              "role" : null
-            },
-            {
-              "name" : "Johnston, Jeremy",
-              "id" : "jj",
-              "role" : null
-            },
-            {
-              "name" : "Clark, Linda",
-              "id" : "lc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
-            }
-          ],
-          "creator" : [
-            {
-              "name" : "Cody, William Frederick, 1846-1917"
-            }
-          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Cather, Meta Schaper; Cather, Roscoe; Cather, Meta Schaper; Brockway, Virginia Cather; ; Cather, Charles Douglass 'Douglass'",
           "keywords" : [ ],
           "places" : [
-            "Shoshone Irrigation District (Wyo.)"
+            "Lander, Wyoming, United States",
+            "Denver, Colorado, United States",
+            "Casper, Wyoming, United States",
+            "Red Cloud, Nebraska, United States"
           ],
           "works" : [ ],
-          "annotations" : null,
-          "text" : "   Col. W. F. Cody, (Buffalo Bill) President.Nate Salsbury, Vice Prest & Manager.John M. Burke, General Manager.Albert E. Sheible, Business Manager.Jule Keen, Treasurer.Buffalo Bill's Wild West and Congress of Rough Riders of the World.The Largest Arenic Exhibition known in History.Col. W. F. Cody Nate SalsburySeason of 1895.Staff of Jas. A. Bailey, Director of Tour.J. T. McCaddon, Superintendent.W. H. Gardner, Gen'l Agent.M. Coyle, R.R. and Excursion Manager.George O. Starr, Press Agent.C. R. Hutchinson, Treasurer.New York Office, No. 106 W. 37th St.  North Platte Mar 26 1895 61 My Dear George, I wish you would write me c/o Annex AudtoriumAuditorium. Hotel Chicago And tell me how the work is progressing. what time you expect to finish to Sulphur Creek.2 and if you have money enough. what time you can finish so as to put water on the 25000 acres. have you tried the graders? hope you have moovedmoved away from Marquette. Is Rumsey still there. has he paid in the $5000 for his Brother3? Hope you and Rumsey took up the Townsite4 what are you doing about Townsite Say George. Frank Gourard5 Said he was to bring fifteen teams of horses from your ranch for him. Also that I could have some hogs from your place. If so send Frank an order for them to Sheridan. These questions I have asked of you will be asked me when I get East. So please answer at once.  Col. W. F. Cody, (Buffalo Bill) President.Nate Salsbury, Vice Prest & Manager.John M. Burke, General Manager.Albert E. Sheible, Business Manager.Jule Keen, Treasurer.Buffalo Bill's Wild West and Congress of Rough Riders of the World.The Largest Arenic Exhibition known in History.Col. W. F. Cody Nate SalsburySeason of 1895.Staff of Jas. A. Bailey, Director of Tour.J. T. McCaddon, Superintendent.W. H. Gardner, Gen'l Agent.M. Coyle, R.R. and Excursion Manager.George O. Starr, Press Agent.C. R. Hutchinson, Treasurer.New York Office, No. 106 W. 37th St.________ 1895 2 I have to day recd wires from Mondell6 and Burke7 that President8 will sign contracts Monday 23d. I go to Cheyenne tomorrow to consult with State Land board9 & Meade. And do all I can to hurry matters there. Get up Water bonds for Nagle10— Recd wire from Alger that he would ship Samples of grain to Nagle What did you do about Seed for Nagle and our selves? If Nothing. why not write Alger to attend to it. Nagle and party he says will leave Chicago Apr. 15 18th Billings. leave Billings 19. arrive on their lands 25th Can you have water in Ditch for them? With all my work and worry I have got to go rehearsing and jump into a hard summers work. A tired man— But I wontwon't care. If I dontdon't have to bear the blunt of bad management on that Ditch. So for Gods sake George— Keep things straight there.   Yours  Bill   "
+          "annotations" : "Studio portrait of Meta Schaper Cather around the year 1900Roscoe and Meta Cather Collection, University of Nebraska-Lincoln Libraries Cather, Meta Schaper (1884-1973). Cather’s sister-in-law. Meta Schaper was born in Plattsmouth, NE, the second daughter of Robert and Julia Ramke Schaper. After graduating from the University of Nebraska in Lincoln 1903, Meta Schaper taught at Havelock High School in her hometown of Havelock, NE (now part of Lincoln). She met Roscoe Cather when teaching in Fullerton, NE, and they married in 1907. They moved to Lander, WY, in 1909, where she gave birth to three daughters, Virginia and twins Margaret and Elizabeth. The family moved to Casper, WY, in 1921 and Colusa, CA, in 1937. Willa visited Meta and Roscoe’s family in Wyoming several times and shared important travel experiences with them, including a 1926 trip to New Mexico with Meta, Roscoe, and their children and a 1941 San Francisco vacation with Roscoe and Meta. Meta and Willa remained friends until Willa’s death.Roscoe CatherRoscoe and Meta Cather Collection, University of Nebraska-Lincoln Libraries Cather, Roscoe (1877-1945) (“Ross”). Cather’s brother. Roscoe was born in Virginia, the second child and oldest son of Charles and Virginia Cather. After graduating from Red Cloud (NE) High School in 1895, he taught country school for two years, attended the University of Nebraska in Lincoln for one year (1897-1898), taught high school in Carlton, NE, and Oxford, NE, and finally became superintendent of schools in Fullerton, NE. There he met fellow teacher Meta Schaper, whom he married in 1907. They relocated to Lander, WY, in 1909, where he opened an abstract office and where their three children, Virginia and twins Margaret and Elizabeth, were born. In 1921, they moved to Casper, WY, where Roscoe became president of the Wyoming Trust Company, and in 1937 to Colusa, CA, where Roscoe and his brother Douglass had acquired a controlling interest in the First Savings Bank of Colusa. Roscoe served as president of the bank until his death. Willa visited Roscoe and his family in Wyoming several times and shared important travel experiences with them, including a 1926 trip to New Mexico with Roscoe, Meta, and their children and a 1941 San Francisco vacation with Roscoe and Meta. She also relied on him to handle family-related business as well as personal financial matters, and he was one of her chief correspondents throughout her life. Roscoe served as a prototype for one of the twin brothers in the Templeton family in “Old Mrs. Harris” (1932).Studio portrait of Meta Schaper Cather around the year 1900Roscoe and Meta Cather Collection, University of Nebraska-Lincoln Libraries Cather, Meta Schaper (1884-1973). Cather’s sister-in-law. Meta Schaper was born in Plattsmouth, NE, the second daughter of Robert and Julia Ramke Schaper. After graduating from the University of Nebraska in Lincoln 1903, Meta Schaper taught at Havelock High School in her hometown of Havelock, NE (now part of Lincoln). She met Roscoe Cather when teaching in Fullerton, NE, and they married in 1907. They moved to Lander, WY, in 1909, where she gave birth to three daughters, Virginia and twins Margaret and Elizabeth. The family moved to Casper, WY, in 1921 and Colusa, CA, in 1937. Willa visited Meta and Roscoe’s family in Wyoming several times and shared important travel experiences with them, including a 1926 trip to New Mexico with Meta, Roscoe, and their children and a 1941 San Francisco vacation with Roscoe and Meta. Meta and Willa remained friends until Willa’s death.Brockway, Virginia Cather (1912-1983) (“West Virginia”). Cather's niece. Born in Lander, WY, to Roscoe Cather and Meta Schaper Cather, Virginia graduated from Natrona County High School in Casper, WY, in 1929. She received an A.B. in English from Smith College in Northampton, MA, in 1933, the same year Willa Cather received an honorary doctorate there. In 1934, she enrolled in the University of Chicago School of Social Services and was, for a time, a social worker. She married John Hadley Brockway, a Navy officer, in 1936. They moved frequently until his retirement from the Navy. She had one child, son George. In letters, Willa Cather sometimes calls her \"West Virginia\" to distinguish her from her cousin Mary Virginia Auld because Virginia Cather's birthplace in Wyoming was farther west than Mary Virginia's in Nebraska.Portrait of Charles Douglas CatherNebraska State Historical Society Cather, Charles Douglas (1880-1938) (“Douglass”). Cather’s brother. Born in Virginia and raised in Red Cloud, NE, Charles was third child and second son of Charles and Virginia Cather. As an adolescent, Douglass Cather helped his father supervise rented farm properties and worked as a messenger for the local Burlington & Missouri Railroad office. In 1897 he left Red Cloud for a position in Sterling, CO, and then took a position with at the Cheyenne, WY, office of the Burlington Railroad. In 1908 he traveled to Mexico, an experience that his sister gave to Emil Bergson in O Pioneers! (1913). By 1910 he was living in Winslow, AZ, still working for the Burlington, where Willa Cather visited him in 1912. He later achieved success in the oil business in California. Although he never married, Cather notes that during the last six or seven years of his life he had a relationship with a Miss Rogers. Douglass visited Cather in New York City in December of 1937. His death in June 1938 left her devastated. Douglass served as a prototype for one of the twin brothers in the Templeton family in “Old Mrs. Harris” (1932) and Hector the messenger boy brother in “The Best Years” (1948). His years working for the Burlington also inspired Cather’s many railroad worker characters in her novels, including Song of the Lark (1915) and The Professor’s House (1925). Few letters from this important sibling relationship have survived.",
+          "text" : "Mr. R. C. Cather, Lander Wyoming DENVER, COLO. AUG 16 1916 11.30 AM THE BROWN PALACE HOTELDENVER THE BROWN PALACE HOTELDENVER Wednesday Dear Meta: The shoe men here tell me that number twos are the smallest shoes made with soles. I am afraid they will be a little large, but if they are the babies will soon grow to them. The black shoes were all much too ugly to send to cunning babies. I got some cleaning stuff to keep these white. When they get very dirty you can wash them with soap and cold water and then rub this birch powder in after they dry. I met Mrs. Goodwin at the hotel in Casper. We had dinner together and she walked to the train with me and told me most of the secrets of her life, and how she desires to write a novel about the sun-dance, with \"a light love theme woven in\"! Miss Ross, it seems, is preparing to write an Indian novel and is stealing copy off the poor devils all the while she pretends to be saving their souls. Douglass is looking better than he has for a long time, and seems to be in good spirits. We go on to Red Cloud tonight. Now I am going to \"Prof. J.T. Ryan\" for a shampoo. Please hug the babies for me, and tell them I hope their little shoes will be comfy. With a great deal of love to you all Willa"
         },
         "highlight" : {
           "text" : [
-            " time you can finish so as to put <em>water</em> on the 25000 acres. have you tried the graders? hope you",
-            " & Meade. And do all I can to hurry matters there. Get up <em>Water</em> bonds for Nagle10— Recd wire from Alger",
-            " 18th Billings. leave Billings 19. arrive on their lands 25th Can you have <em>water</em> in Ditch for them"
+            " <em>water</em> and then rub this birch powder in after they dry. I met Mrs. Goodwin at the hotel in Casper. We"
           ]
         }
       },
       {
         "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00526",
-        "_score" : 3.9872563,
+        "_type" : "cather",
+        "_id" : "cat.let2785",
+        "_score" : 3.7249577,
         "_source" : {
-          "identifier" : "wfc.css00526",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
+          "identifier" : "cat.let2785",
+          "category" : "Writings",
+          "subcategory" : "Letters",
           "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, july 28, 1898",
-          "title" : "Letter from William F. Cody to George T. Beck, July 28, 1898",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to helen louise cather southwick, [february 1946]",
+          "title" : "Willa Cather to Helen Louise Cather Southwick, [February 1946]",
           "description" : null,
           "format" : "letter",
           "language" : null,
           "medium" : "letter",
-          "date_display" : "July 28, 1898",
-          "date" : "1898-07-28",
-          "date_not_before" : "1898-07-28",
-          "date_not_after" : "1898-07-28",
+          "date_display" : "N.D.",
+          "date" : null,
+          "date_not_before" : null,
+          "date_not_after" : null,
           "rights_uri" : null,
-          "publisher" : "",
+          "publisher" : "University of Nebraska–Lincoln",
           "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill Letters to George T. Beck (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
+          "source" : "University of Nebraska-Lincoln, Archives and Special Collection, Lincoln, NE",
+          "rights_holder" : "University of Nebraska-Lincoln, Archives and Special Collection, Lincoln, NE",
           "person" : [
             {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
+              "name" : "Southwick, Helen Louise Cather",
+              "id" : "0872",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Southwick, Helen Louise Cather",
+              "id" : "0872"
+            },
+            {
+              "name" : "Cather, Charles Edwin",
+              "id" : "0179"
+            },
+            {
+              "name" : "Cather, James Donald",
+              "id" : "0195"
+            },
+            {
+              "name" : "Cather, Ethel Garber",
+              "id" : "0190"
             }
           ],
           "contributor" : [
             {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
             },
             {
-              "name" : "Houze, Lynn",
-              "id" : "lh",
-              "role" : null
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
             },
             {
-              "name" : "Johnston, Jeremy",
-              "id" : "jj",
-              "role" : null
-            },
-            {
-              "name" : "Clark, Linda",
-              "id" : "lc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
             }
           ],
           "creator" : [
             {
-              "name" : "Cody, William Frederick, 1846-1917"
+              "name" : "Willa Cather"
             }
           ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Southwick, Helen Louise Cather; Southwick, Helen Louise Cather; Cather, Charles Edwin; Cather, James Donald; Cather, Ethel Garber",
           "keywords" : [ ],
-          "places" : [ ],
+          "places" : [
+            "New York, New York, United States"
+          ],
           "works" : [ ],
-          "annotations" : null,
-          "text" : "   Buffalo Bill's Wild West  Chicago1 July 282 My Dear Beck Those Preists3 want their deeds to their Lots— I wish you would let me know if you are now ready and will make them out for them? Snyder4 writes me you have gone South to work for Alger— not but what I approoveapprove of it. But I cantcan't beleivebelieve that you would leave until the water was again runingrunning. If you have left our business just at this critical time— Its not right And I will so notify the Co. I hope itsit's not true— Very truly yours W. F. Cody  "
+          "annotations" : "Southwick, Helen Louise Cather (1918-2004). Cather’s niece. Helen was born in Red Cloud, NE, to Willa Cather’s brother James and his wife Ethel. Willa was a doting aunt on her visits to Red Cloud. In 1931, Helen moved with her family to Long Beach, CA, where she graduated high school and attended Long Beach City College. In 1939, Helen returned to Red Cloud to help care for her maternal grandmother and then enrolled in the University of Nebraska in Lincoln, where she met her future husband, Philip Southwick. After graduating in 1941, she briefly returned to California to work in the personnel department of Douglas Aircraft company, but married Southwick in Lincoln in 1942, and then moved with him to Champagne, IL. When Philip’s employment took them to Plainfield, NJ, she frequently spent time with her aunt in New York City. In 1946, the Southwicks moved to Pittsburgh, PA, where their son James was born. In later years Helen worked as a school librarian and was active in the Cather Foundation in Red Cloud, NE. She was a beneficiary of Cather’s literary estate, and when Edith Lewis died in 1972 she bequeathed Cather books and manuscripts to Helen and her brother Charles Cather. Helen donated her share of these materials and Willa Cather’s letters to her to the University of Nebraska-Lincoln.Southwick, Helen Louise Cather (1918-2004). Cather’s niece. Helen was born in Red Cloud, NE, to Willa Cather’s brother James and his wife Ethel. Willa was a doting aunt on her visits to Red Cloud. In 1931, Helen moved with her family to Long Beach, CA, where she graduated high school and attended Long Beach City College. In 1939, Helen returned to Red Cloud to help care for her maternal grandmother and then enrolled in the University of Nebraska in Lincoln, where she met her future husband, Philip Southwick. After graduating in 1941, she briefly returned to California to work in the personnel department of Douglas Aircraft company, but married Southwick in Lincoln in 1942, and then moved with him to Champagne, IL. When Philip’s employment took them to Plainfield, NJ, she frequently spent time with her aunt in New York City. In 1946, the Southwicks moved to Pittsburgh, PA, where their son James was born. In later years Helen worked as a school librarian and was active in the Cather Foundation in Red Cloud, NE. She was a beneficiary of Cather’s literary estate, and when Edith Lewis died in 1972 she bequeathed Cather books and manuscripts to Helen and her brother Charles Cather. Helen donated her share of these materials and Willa Cather’s letters to her to the University of Nebraska-Lincoln.Cather, Charles Edwin (1923-2011). Cather’s nephew. Charles’s parents were James D. and Ethel Garber Cather, and he was likely born in Red Cloud, NE, where he spent the early years of his childhood. He was, as Willa Cather wrote to Dorothy Canfield Fisher, “the little nephew I love the best” who inspired her portrayal of the little boy Jacques in Shadows on the Rock (1931) (#1054). He moved with his family to California in the 1930s. Cather continued to be an indulgent aunt as he got older, writing him letters of advice about and lending him money for his education. He attended, but did not complete degrees from, the University of Nebraska in Lincoln, the United States Military Academy in West Point, NY, and the Law School at the University of Colorado in Boulder. After his aunt’s death he completed undergraduate and law degrees at Stanford University, in Palo Alto, CA. He was a beneficiary of his aunt’s estate and was appointed her literary executor after Edith Lewis’s death.Cather, James Donald (1886-1966) (“Jim”). Cather’s brother. James was born in Red Cloud, NE, the fifth child and third son of Charles and Virginia Cather. James moved to Wyoming in 1907 to work with his brothers Douglass and Roscoe. In 1913 he married Ethel Garber, and owned and operated clothing stores first in Red Cloud and then Holyoke, CO, where the family settled for a time 1920 before returning to Red Cloud in 1922. The couple had two children, Helen Louise and Charles Edwin. In 1930 the family moved to California so James could work in the oil business with Douglass and his partners. Willa’s relationship with James was more distant than that with her brothers Douglass and Roscoe, who were closer to her own age, although she was very fond of his children.Cather, Ethel Garber (1889-1975). Cather’s sister-in-law. Ethel was the daughter of Edwin S. Garber and through him was related to Governor Silas Garber, the model for Captain Forrester in A Lost Lady (1923). Ethel graduated from the University of Nebraska in Lincoln in 1909 and married James Cather in 1913. The couple had two children, Helen Louise and Charles Edwin. The family moved to California in 1930. Ethel and Willa Cather were not close.",
+          "text" : "Wednesday My Dear— I have telephoned you every day since I came home from the Hospital one week ago (Westfield 2-5586-J is that still the right number?) There are so many things I want to thank you for! The lovely iris and jonquils you bought me from you and Charles outlived and out-shone many other flowers because you brought them in from the country, whereas flowers ordered from a New York florist go through the middlemen before they reach the shop. A fine bottle of cologne water came from Jim and Ethel, but I think you must have selected it. Please thank them—I will write them when I ean can. This is the first time I have taken up a pen, and my hand is still a bit crabbed. No wonder you have had influenza—was there ever such devilish weather! Oh yes, the operation turned out very well—there was nothing ugly or alarming in the bump. Surger is rather exhausting, however. Lovingly Your Aunt Willa"
         },
         "highlight" : {
           "text" : [
-            " cantcan't beleivebelieve that you would leave until the <em>water</em> was again runingrunning. If you have left our"
+            " florist go through the middlemen before they reach the shop. A fine bottle of cologne <em>water</em> came from"
           ]
         }
       },
       {
         "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00534",
-        "_score" : 3.9872563,
+        "_type" : "cather",
+        "_id" : "cat.let0506",
+        "_score" : 3.6736455,
         "_source" : {
-          "identifier" : "wfc.css00534",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
+          "identifier" : "cat.let0506",
+          "category" : "Writings",
+          "subcategory" : "Letters",
           "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, june 2, 1899",
-          "title" : "Letter from William F. Cody to George T. Beck, June 2, 1899",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to ferris greenslet, may 8, 1920",
+          "title" : "Willa Cather to Ferris Greenslet, May 8, 1920",
           "description" : null,
           "format" : "letter",
           "language" : null,
           "medium" : "letter",
-          "date_display" : "June 2, 1899",
-          "date" : "1899-06-02",
-          "date_not_before" : "1899-06-02",
-          "date_not_after" : "1899-06-02",
+          "date_display" : "May 8, 1920",
+          "date" : "1920-05-08",
+          "date_not_before" : "1920-05-08",
+          "date_not_after" : "1920-05-08",
           "rights_uri" : null,
-          "publisher" : "",
+          "publisher" : "University of Nebraska–Lincoln",
           "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill: Letters to George T. Beck, 1895-1910 (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
+          "source" : "Harvard University, Houghton Library, Cambridge, MA",
+          "rights_holder" : "Harvard University, Houghton Library, Cambridge, MA",
           "person" : [
             {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
+              "name" : "Greenslet, Ferris",
+              "id" : "0401",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Greenslet, Ferris",
+              "id" : "0401"
+            },
+            {
+              "name" : "Walpole, Hugh",
+              "id" : "0971"
             }
           ],
           "contributor" : [
             {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
             },
             {
-              "name" : "Christianson, Johnston, Houze, Clark",
-              "id" : "bbhc",
-              "role" : null
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
             },
             {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
             }
           ],
           "creator" : [
             {
-              "name" : "Cody, William Frederick, 1846-1917"
+              "name" : "Willa Cather"
             }
           ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Greenslet, Ferris; Greenslet, Ferris; Walpole, Hugh",
           "keywords" : [ ],
-          "places" : [ ],
+          "places" : [
+            "New York, New York, United States",
+            "Italy",
+            "Paris, Île-de-France, France"
+          ],
           "works" : [ ],
-          "annotations" : null,
-          "text" : "   Louis E. Cooke, Gen'l Agent.Buffalo Bill's Wild West andCongress of Rough Ridersof the World. Col. W. F. Cody (Buffalo Bill), President. Nate Salsbury, Vice-President & Manager. John M. Burke, General Manager.Albert E. Sheible, Business Manager.Jule Keen, Treasurer.  Phila Pa1 June. 2d 99 My Dear Beck Every day now every mail every telegrame Boy I see- I say there is water running in the streets of Cody. Say. I think we should fix the road through to Frosts2 I understand it wontwon't cost over $25— Yours in haste Cody  "
+          "annotations" : "Ferris Greenslet's 1921 passport photo.The National Archives Greenslet, Ferris (1875-1959). American editor and writer. Born in Glens Falls, NY, Ferris Greenslet earned a B.A. (1897) from Wesleyan University and a Ph.D. (1900) from Columbia University. After serving as associate editor at the Atlantic Monthly from 1902 to 1907, Greenslet became literary editor at Houghton Mifflin in Boston, MA, where he championed Willa Cather’s early novels. As an author he specialized in biography. He was socially and professionally acquainted with Cather’s friends Annie Adams Fields and Sarah Orne Jewett, who may have introduced her to him in 1908. He became a director of Houghton Mifflin in 1919 and manager of the trade department in 1933. Greenslet and Cather’s correspondence provides many insights into Cather’s career. Although Cather left Houghton Mifflin as a publisher because she became dissatisfied with the production and advertising of her books, she remained on cordial terms with Greenslet.Ferris Greenslet's 1921 passport photo.The National Archives Greenslet, Ferris (1875-1959). American editor and writer. Born in Glens Falls, NY, Ferris Greenslet earned a B.A. (1897) from Wesleyan University and a Ph.D. (1900) from Columbia University. After serving as associate editor at the Atlantic Monthly from 1902 to 1907, Greenslet became literary editor at Houghton Mifflin in Boston, MA, where he championed Willa Cather’s early novels. As an author he specialized in biography. He was socially and professionally acquainted with Cather’s friends Annie Adams Fields and Sarah Orne Jewett, who may have introduced her to him in 1908. He became a director of Houghton Mifflin in 1919 and manager of the trade department in 1933. Greenslet and Cather’s correspondence provides many insights into Cather’s career. Although Cather left Houghton Mifflin as a publisher because she became dissatisfied with the production and advertising of her books, she remained on cordial terms with Greenslet.No annotation is available",
+          "text" : "FG May 8th, 1920 Dear Mr. Greenslet; I could not answer your note and thank you for the check before this, as I have been laid low by inocculation against typhoid. Next time I'll take my chances with the disease itself. I don't expect to drink much water in Italy, anyhow. My Paris address will be care of Thomas Cook and Sons. So far, everything seems to promise a good trip. I had a delightful hour with Hugh Walpole before he sailed. Faithfully yours W. S. C."
         },
         "highlight" : {
           "text" : [
-            " Dear Beck Every day now every mail every telegrame Boy I see- I say there is <em>water</em> running in the"
+            " the disease itself. I don't expect to drink much <em>water</em> in Italy, anyhow. My Paris address will be"
           ]
         }
       },
       {
         "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00524",
-        "_score" : 3.9872563,
+        "_type" : "cather",
+        "_id" : "cat.let2340",
+        "_score" : 3.6351402,
         "_source" : {
-          "identifier" : "wfc.css00524",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
+          "identifier" : "cat.let2340",
+          "category" : "Writings",
+          "subcategory" : "Letters",
           "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from william f. cody to george t. beck, july 19, 1898",
-          "title" : "Letter from William F. Cody to George T. Beck, July 19, 1898",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to elizabeth cather and margaret cather, august 12 [1936]",
+          "title" : "Willa Cather to Elizabeth Cather and Margaret Cather, August 12 [1936]",
           "description" : null,
           "format" : "letter",
           "language" : null,
           "medium" : "letter",
-          "date_display" : "July 19, 1898",
-          "date" : "1898-07-19",
-          "date_not_before" : "1898-07-19",
-          "date_not_after" : "1898-07-19",
+          "date_display" : "August 12, 1936",
+          "date" : "1936-08-12",
+          "date_not_before" : "1936-08-12",
+          "date_not_after" : "1936-08-12",
           "rights_uri" : null,
-          "publisher" : "",
+          "publisher" : "University of Nebraska–Lincoln",
           "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "University of Wyoming, American Heritage Center, Buffalo Bill Letters to George T. Beck (Acc. #9972)",
-          "creator_sort" : "Cody, William Frederick, 1846-1917",
-          "people" : "Beck, George Washington Thornton, 1856-1943",
+          "source" : "University of Nebraska–Lincoln, Archives and Special Collections",
+          "rights_holder" : "University of Nebraska–Lincoln, Archives and Special Collections",
           "person" : [
             {
-              "role" : null,
-              "name" : "Beck, George Washington Thornton, 1856-1943",
-              "id" : ""
+              "name" : "Shannon, Margaret Cather",
+              "id" : "0197",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Shannon, Margaret Cather",
+              "id" : "0197"
+            },
+            {
+              "name" : "Beal, Mrs.",
+              "id" : "0078"
+            },
+            {
+              "name" : "Beal, Ralph L.",
+              "id" : "0079"
+            },
+            {
+              "name" : "Lewis, Edith",
+              "id" : "0560"
+            },
+            {
+              "name" : "Bromhall, Miss",
+              "id" : "0135"
+            },
+            {
+              "name" : "Jordan, Mary Adela",
+              "id" : "0494"
+            },
+            {
+              "name" : "Glissing, Miss",
+              "id" : "0378"
+            },
+            {
+              "name" : "Cather, Roscoe",
+              "id" : "0200"
+            },
+            {
+              "name" : "Cather, Meta Schaper",
+              "id" : "0199"
             }
           ],
           "contributor" : [
             {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
             },
             {
-              "name" : "Houze, Lynn",
-              "id" : "lh",
-              "role" : null
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
             },
             {
-              "name" : "Johnston, Jeremy",
-              "id" : "jj",
-              "role" : null
-            },
-            {
-              "name" : "Clark, Linda",
-              "id" : "lc",
-              "role" : null
-            },
-            {
-              "name" : "Boyce, Gary",
-              "id" : "gb",
-              "role" : null
-            },
-            {
-              "name" : "Adams, Deb",
-              "id" : "da",
-              "role" : null
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
             }
           ],
           "creator" : [
             {
-              "name" : "Cody, William Frederick, 1846-1917"
+              "name" : "Willa Cather"
             }
           ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Shannon, Margaret Cather; Shannon, Margaret Cather; Beal, Mrs.; Beal, Ralph L.; Lewis, Edith; Bromhall, Miss; Jordan, Mary Adela; Glissing, Miss; Cather, Roscoe; Cather, Meta Schaper",
           "keywords" : [ ],
-          "places" : [ ],
+          "places" : [
+            "Grand Manan, New Brunswick, Canada",
+            ""
+          ],
           "works" : [ ],
-          "annotations" : null,
-          "text" : "   Buffalo Bill's Wild West Traverse City Mich1 July 192 My Dear Beck Yours recd— Now if Forbs3 wontwon't put up— Nor Bleistein & others— the mill will have to go over another year. I cantcan't build it Alone— The timber might be sawed for it. For the mill will have to be built Sooner or later— And the mill lumber will keep— And we will have it ready— If Bleistein wires me he can raise two or three thousand allright. But it must be a steam and water mill combined what will it cost to add  steam? How much did Jones4 owe— colony people5?  Yours truly W. F. Cody  Excuse blots raining like L5—  "
+          "annotations" : "Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.No annotation is availableNo annotation is availableEdith Lewis in the 1920sCharles E. Cather Collection, University of Nebraska-Lincoln Libraries Lewis, Edith Labaree (1881-1972). Magazine editor, advertising copywriter, and Cather's domestic partner. Born in Lincoln, NE, to Henry Euclid Lewis and Lillie Gould Lewis, Edith Lewis attended the preparatory school associated with the University of Nebraska, earning college credits from the University before transferring to Smith College in Northampton, MA, in 1899. She received an A.B. in English from Smith in 1902 and returned home to teach elementary school. She met Willa Cather in the summer of 1903 at the home of Sarah Harris, publisher of the Lincoln Courier. Moving to New York City soon afterward, Lewis settled into a studio on Washington Square and found work at the Century Publishing Company. Cather was her guest when she visited the city from Pittsburgh. In 1906, at Cather's suggestion, Lewis applied for a position as an editorial proofreader at McClure's Magazine, and the two women worked together on the McClure's staff for six years. In 1908, they moved into a shared apartment at 82 Washington Place, and then, in 1912, to Five Bank Street. Lewis left McClure's in 1915 to become managing editor of Every Week Magazine, where she stayed until the magazine folded in 1918. In 1919 she began a long career as an advertising copywriter at the J. Walter Thompson Co. In 1926 Edith Lewis acquired the land on which she and Cather built their cottage on Grand Manan Island. When they lost their apartment on Bank Street to subway construction in 1927, they shared quarters at the Grosvenor Hotel when they were both in New York City. In 1932 they took an apartment at 570 Park Avenue. Throughout their relationship, Lewis was closely involved in Cather's creative process, reading and editing her work in pre-publication forms. Cather's will appointed Lewis as executor of her literary estate and a beneficiary of her literary trust. Lewis authorized E.K. Brown as Cather's first biographer and published her own memoir of Cather, Willa Cather Living (1953). She remained in their Park Avenue apartment after Cather's death and died there after a long period of illness and invalidism. She is buried at Cather's side in Jaffrey, NH.No annotation is availableNo annotation is availableNo annotation is availableRoscoe CatherRoscoe and Meta Cather Collection, University of Nebraska-Lincoln Libraries Cather, Roscoe (1877-1945) (“Ross”). Cather’s brother. Roscoe was born in Virginia, the second child and oldest son of Charles and Virginia Cather. After graduating from Red Cloud (NE) High School in 1895, he taught country school for two years, attended the University of Nebraska in Lincoln for one year (1897-1898), taught high school in Carlton, NE, and Oxford, NE, and finally became superintendent of schools in Fullerton, NE. There he met fellow teacher Meta Schaper, whom he married in 1907. They relocated to Lander, WY, in 1909, where he opened an abstract office and where their three children, Virginia and twins Margaret and Elizabeth, were born. In 1921, they moved to Casper, WY, where Roscoe became president of the Wyoming Trust Company, and in 1937 to Colusa, CA, where Roscoe and his brother Douglass had acquired a controlling interest in the First Savings Bank of Colusa. Roscoe served as president of the bank until his death. Willa visited Roscoe and his family in Wyoming several times and shared important travel experiences with them, including a 1926 trip to New Mexico with Roscoe, Meta, and their children and a 1941 San Francisco vacation with Roscoe and Meta. She also relied on him to handle family-related business as well as personal financial matters, and he was one of her chief correspondents throughout her life. Roscoe served as a prototype for one of the twin brothers in the Templeton family in “Old Mrs. Harris” (1932).Studio portrait of Meta Schaper Cather around the year 1900Roscoe and Meta Cather Collection, University of Nebraska-Lincoln Libraries Cather, Meta Schaper (1884-1973). Cather’s sister-in-law. Meta Schaper was born in Plattsmouth, NE, the second daughter of Robert and Julia Ramke Schaper. After graduating from the University of Nebraska in Lincoln 1903, Meta Schaper taught at Havelock High School in her hometown of Havelock, NE (now part of Lincoln). She met Roscoe Cather when teaching in Fullerton, NE, and they married in 1907. They moved to Lander, WY, in 1909, where she gave birth to three daughters, Virginia and twins Margaret and Elizabeth. The family moved to Casper, WY, in 1921 and Colusa, CA, in 1937. Willa visited Meta and Roscoe’s family in Wyoming several times and shared important travel experiences with them, including a 1926 trip to New Mexico with Meta, Roscoe, and their children and a 1941 San Francisco vacation with Roscoe and Meta. Meta and Willa remained friends until Willa’s death.",
+          "text" : "Air Mail The Misses Cather 1225 South Centre Street Casper Wyoming U. S. A. NORTH HEAD, N. B. AU 10 36 AM ⬩W⬩S⬩C⬩ August 12th My Darling Twinnies; My rose is a curtain of bloom, from root to tip, and the hollyhocks are going strong. Now the golden rod on the edge of the cliffs waves against a purple sea, all the way up to the High Place. Last week the moon rose further and further north every night, first over the tip of fishhead, and finally right in front of our door—came up out of the water like a battered old copper kettle as it grew more and more lop–sided. It made such a bright, narrow path right to the foot of our cliff that one was tempted to walk across it. The weather has been wonderful—blue and gold every day, with good rains at night. Our lawn is very green now, and the monkshood makes a violet hedge against the gray house. It is so mild now, the weather, that we can sit out in our steamer chairs after dinner. The fire places have not been lit for a week. Mrs. Beal & Ralph are here cleaning house today, and I am now writing in the attic. We read the proofs of the new book last week. On Saturday we walked to Bright Angels, but no sweet twin did follow. We both miss you very much and often wish you were here. On Friday Miss Bromhall came for tea. She and Miss Jordan and Miss Glissing and many others wish to be remembered to you—they also miss you. You must both come here again, my dears, before you do any desperate thing like getting ⬩W⬩S⬩C⬩ married. If we all three wish it, we can make it come true. Next time it must be in August, when all the flowers are out, and the water warms enough to bathe in, and the whales due to arrive. The morning you left we got up early and waited on the shore, but we couldn't even see the boat. I wish your father and mother could have come on up [on an ] airplane and dropped down on us while you were here. Perhaps they can, next time, and we can go to the Wolves and out to Gunnet Light. Tomorrow we go to Southern Head if it is fine, and I shall remember the happy day we had there with you. A world of love to you, my dears. from your Aunt Willie"
         },
         "highlight" : {
           "text" : [
-            " three thousand allright. But it must be a steam and <em>water</em> mill combined what will it cost to add  steam"
+            " night, first over the tip of fishhead, and finally right in front of our door—came up out of the <em>water</em>",
+            ", and the <em>water</em> warms enough to bathe in, and the whales due to arrive. The morning you left we got up"
           ]
         }
       },
       {
         "_index" : "test1",
-        "_type" : "cody",
-        "_id" : "wfc.css00366",
-        "_score" : 3.9630013,
+        "_type" : "cather",
+        "_id" : "cat.let2358",
+        "_score" : 3.5972924,
         "_source" : {
-          "identifier" : "wfc.css00366",
-          "category" : "Texts",
-          "subcategory" : "Correspondence",
+          "identifier" : "cat.let2358",
+          "category" : "Writings",
+          "subcategory" : "Letters",
           "data_type" : "tei",
-          "project" : "Buffalo Bill Cody",
-          "shortname" : "cody",
-          "title_sort" : "letter from c. m. morrill to c. e. perkins, november 4, 1899",
-          "title" : "Letter from C. M. Morrill to C. E. Perkins, November 4, 1899",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to margaret cather, [july 16, 1938]",
+          "title" : "Willa Cather to Margaret Cather, [July 16, 1938]",
           "description" : null,
           "format" : "letter",
           "language" : null,
           "medium" : "letter",
-          "date_display" : "November 4, 1899",
-          "date" : "1899-11-04",
-          "date_not_before" : "1899-11-04",
-          "date_not_after" : "1899-11-04",
+          "date_display" : "July 16, 1938",
+          "date" : "1938-07-16",
+          "date_not_before" : "1938-07-16",
+          "date_not_after" : "1938-07-16",
           "rights_uri" : null,
-          "publisher" : "",
+          "publisher" : "University of Nebraska–Lincoln",
           "rights" : "All Rights Reserved",
-          "source" : "",
-          "rights_holder" : "Newberry Library, CB&Q collection, 33, 1890, 6.8, Big Horn Basin",
-          "creator_sort" : "",
-          "people" : "",
+          "source" : "University of Nebraska–Lincoln, Archives and Special Collections",
+          "rights_holder" : "University of Nebraska–Lincoln, Archives and Special Collections",
           "person" : [
             {
-              "role" : null,
+              "name" : "Shannon, Margaret Cather",
+              "id" : "0197",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Shannon, Margaret Cather",
+              "id" : "0197"
+            },
+            {
+              "name" : "Cather, Roscoe",
+              "id" : "0200"
+            },
+            {
+              "name" : "Lewis, Edith",
+              "id" : "0560"
+            },
+            {
+              "name" : "Jacobus, Sarah Hayes",
+              "id" : "0479"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Shannon, Margaret Cather; Shannon, Margaret Cather; Cather, Roscoe; Lewis, Edith; Jacobus, Sarah Hayes",
+          "keywords" : [ ],
+          "places" : [
+            "St. John, New Brunswick, Canada",
+            "Colusa, California, United States",
+            "Long Beach, California, United\n                            States",
+            "Grand Manan, New Brunswick, Canada"
+          ],
+          "works" : [ ],
+          "annotations" : "Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Roscoe CatherRoscoe and Meta Cather Collection, University of Nebraska-Lincoln Libraries Cather, Roscoe (1877-1945) (“Ross”). Cather’s brother. Roscoe was born in Virginia, the second child and oldest son of Charles and Virginia Cather. After graduating from Red Cloud (NE) High School in 1895, he taught country school for two years, attended the University of Nebraska in Lincoln for one year (1897-1898), taught high school in Carlton, NE, and Oxford, NE, and finally became superintendent of schools in Fullerton, NE. There he met fellow teacher Meta Schaper, whom he married in 1907. They relocated to Lander, WY, in 1909, where he opened an abstract office and where their three children, Virginia and twins Margaret and Elizabeth, were born. In 1921, they moved to Casper, WY, where Roscoe became president of the Wyoming Trust Company, and in 1937 to Colusa, CA, where Roscoe and his brother Douglass had acquired a controlling interest in the First Savings Bank of Colusa. Roscoe served as president of the bank until his death. Willa visited Roscoe and his family in Wyoming several times and shared important travel experiences with them, including a 1926 trip to New Mexico with Roscoe, Meta, and their children and a 1941 San Francisco vacation with Roscoe and Meta. She also relied on him to handle family-related business as well as personal financial matters, and he was one of her chief correspondents throughout her life. Roscoe served as a prototype for one of the twin brothers in the Templeton family in “Old Mrs. Harris” (1932).Edith Lewis in the 1920sCharles E. Cather Collection, University of Nebraska-Lincoln Libraries Lewis, Edith Labaree (1881-1972). Magazine editor, advertising copywriter, and Cather's domestic partner. Born in Lincoln, NE, to Henry Euclid Lewis and Lillie Gould Lewis, Edith Lewis attended the preparatory school associated with the University of Nebraska, earning college credits from the University before transferring to Smith College in Northampton, MA, in 1899. She received an A.B. in English from Smith in 1902 and returned home to teach elementary school. She met Willa Cather in the summer of 1903 at the home of Sarah Harris, publisher of the Lincoln Courier. Moving to New York City soon afterward, Lewis settled into a studio on Washington Square and found work at the Century Publishing Company. Cather was her guest when she visited the city from Pittsburgh. In 1906, at Cather's suggestion, Lewis applied for a position as an editorial proofreader at McClure's Magazine, and the two women worked together on the McClure's staff for six years. In 1908, they moved into a shared apartment at 82 Washington Place, and then, in 1912, to Five Bank Street. Lewis left McClure's in 1915 to become managing editor of Every Week Magazine, where she stayed until the magazine folded in 1918. In 1919 she began a long career as an advertising copywriter at the J. Walter Thompson Co. In 1926 Edith Lewis acquired the land on which she and Cather built their cottage on Grand Manan Island. When they lost their apartment on Bank Street to subway construction in 1927, they shared quarters at the Grosvenor Hotel when they were both in New York City. In 1932 they took an apartment at 570 Park Avenue. Throughout their relationship, Lewis was closely involved in Cather's creative process, reading and editing her work in pre-publication forms. Cather's will appointed Lewis as executor of her literary estate and a beneficiary of her literary trust. Lewis authorized E.K. Brown as Cather's first biographer and published her own memoir of Cather, Willa Cather Living (1953). She remained in their Park Avenue apartment after Cather's death and died there after a long period of illness and invalidism. She is buried at Cather's side in Jaffrey, NH.Jacobus, Sarah Hayes (1875-1948). Proprietor of the Whale Cove Inn, Grand Manan Island. An 1897 graduate of the Boston Normal School for Gymnastics, Sarah Jacobus \"discovered\" Grand Manan Island with two classmates in 1900, and in 1901 they purchased property at Whale Cove. By the time Willa Cather and Edith Lewis first visited Whale Cove in 1922, the summer colony had become an inn, with guests renting rooms in the main building or in adjacent cottages and taking meals in the inn's dining room. Jacobus was co-owner of the inn, and during the summer season she was in residence as the on-site manager. When summer visitors, including Cather and Lewis, built their own cottages, they continued to take meals in the dining room. In the off seasons from 1920 through 1932 Jacobus lived in Manhattan and worked in the Circulation Department of the New York Public Library. Later in her life, she lived year round on Grand Manan and died there.",
+          "text" : "Admiral Beatty HotelSAINT JOHN, NEW BRUNSWICKCANADA Miss Margaret Cather Villa Riviera Apt. HotelLong Beach 754 Oak StColusa — California SAINT JOHN N.B. JUL 16 1938 AM NOTICELETTERS MAILED IN HOTEL ENVELOPESIF NOT DELIVERED, ARE SENT TO THE DEAD LETTER OFFICEUNLESS THE WRITER GIVES A RETURN ADDRESS.IF NOT DELIVERED IN__DAYS, RETURN TO LONG BEACH CALIF. JUL 21 1938 4 PM Admiral Beatty HotelOPERATED BYADMIRAL BEATTY HOTEL COMPANY LTD.SAINT JOHN, N.B. Isn't this rather nice? You know I love the French prose writers so well. Their poets I don't love so well. Show this this to your Daddy when he is not too busy. With love from us both W. We expected to crossto the Island today but the water is so rough out there Miss Jacobus telegraphed us not to come!"
+        },
+        "highlight" : {
+          "text" : [
+            " is not too busy. With love from us both W. We expected to crossto the Island today but the <em>water</em> is"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let1572",
+        "_score" : 3.538511,
+        "_source" : {
+          "identifier" : "cat.let1572",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to mary miner creighton, february 19, 1942",
+          "title" : "Willa Cather to Mary Miner Creighton, February 19, 1942",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "February 19, 1942",
+          "date" : "1942-02-19",
+          "date_not_before" : "1942-02-19",
+          "date_not_after" : "1942-02-19",
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "Nebraska State Historical Society, Lincoln, NE",
+          "rights_holder" : "Nebraska State Historical Society, Lincoln, NE",
+          "person" : [
+            {
+              "name" : "Creighton, Mary Miner",
+              "id" : "0242",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Creighton, Mary Miner",
+              "id" : "0242"
+            },
+            {
+              "name" : "Sherwood, Carrie Miner",
+              "id" : "0849"
+            },
+            {
+              "name" : "Undset, Sigrid",
+              "id" : "0944"
+            },
+            {
+              "name" : "Knopf, Alfred A.",
+              "id" : "0518"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Creighton, Mary Miner; Creighton, Mary Miner; Sherwood, Carrie Miner; Undset, Sigrid; Knopf, Alfred A.",
+          "keywords" : [ ],
+          "places" : [
+            "unknown place",
+            "Prague, Czech Republic",
+            "CzechoslovakiaCzech\n                                RepublicSlovakiaBohemia",
+            "Bergen, Norway",
+            "Russia",
+            "Vladivostok, Russia",
+            "Sweden",
+            "Japan",
+            "United States"
+          ],
+          "works" : [ ],
+          "annotations" : "Creighton, Mary S. Miner (1873-1968). Clubwoman; Cather’s friend from childhood. Born in Iowa, Mary Miner was the second daughter of James and Julia Miner, neighbors of the Cather family in Red Cloud, NE. Willa Cather later recalled that when she first moved into town with her family and enrolled in school in 1885, “Margie Miner was so jolly I wanted awfully to know her.” They became lifelong friends and correspondents, and Mary’s sisters Irene and Carrie were equally close to Cather. Mary Miner wed local physician E. A. Creighton in 1900 and lived the rest of her life in Red Cloud. She was the prototype for Julia Harling in My Ántonia (1918).Creighton, Mary S. Miner (1873-1968). Clubwoman; Cather’s friend from childhood. Born in Iowa, Mary Miner was the second daughter of James and Julia Miner, neighbors of the Cather family in Red Cloud, NE. Willa Cather later recalled that when she first moved into town with her family and enrolled in school in 1885, “Margie Miner was so jolly I wanted awfully to know her.” They became lifelong friends and correspondents, and Mary’s sisters Irene and Carrie were equally close to Cather. Mary Miner wed local physician E. A. Creighton in 1900 and lived the rest of her life in Red Cloud. She was the prototype for Julia Harling in My Ántonia (1918).Sherwood, Carrie Miner (1869-1971). Cather’s childhood friend. Carrie was the eldest daughter of James and Julia Miner, neighbors of the Cathers in Red Cloud, NE. Carrie was the prototype for Frances Harling in My Ántonia (1918). She was married to Red Cloud banker Walter Sherwood and was Willa Cather’s lifelong friend and correspondent.A portrait of Alfred A. Knopf taken by Carl Van Vechten on March 31, 1935The United States Library of Congress Knopf, Alfred A. (1892-1984). President of New York publisher Alfred A. Knopf, Inc. Knopf received his B.A. from Columbia University in New York City in 1912 and founded Alfred Knopf, Inc., in 1915 with his future wife Blanche Wolf. They married in 1916, and their son Alfred “Pat” Knopf was born in 1918. Cather chose him as her publisher beginning with Youth and the Bright Medusa (1920) and One of Ours (1922), partly because she was dissatisfied with the promotion of her books by Houghton Mifflin but also because she recognized the high quality of Knopf's books, as well as what she regarded as his intelligent advertising. Knopf was noted for publishing the work of leading European and South American writers in translation, as well as original works. Knopf and Cather’s extensive correspondence testifies to their mutual professional respect and to what also became an important personal friendship.",
+          "text" : "⬩W⬩S⬩C⬩ February 19, 1942.My dear Mary: This must be a hurly-burly letter. The unanswered letters have piled up on my desk until I am nearly distracted. Please tell Carrie I cannot answer her dear letter until I have worked off a reply to some that have lain here for three weeks. I merely write this to explain some books I am sending you. When I was weeding out my bookcase for about a hundred books to send to the soldier camps I came across this book on Prague, sent me long ago when Bohemia had a consul generalship here. Many of the books I sent the soldiers were books presented to me with inscriptions, and I went through the lot tearing out the personal dedications. Just as I had torn the inscription from this one, I bethought me that either you or Carrie had been in Prague. I, alas, have never been there. I do not suppose the text of this book is very interesting, but on glancing through it I think some of the drawings are very interesting, and I am sure that whichever one of the Miner sisters has been in Prague will find the book entertaining. Several days ago I ordered from the Channel Book Shop one of the first copies of Sigrid Undset's book about her escape from Norway. I think the title most unfortunate (Why wouldn't she call it simply, \"My Escape From Norway\"?). But Frau Undset is one of the most absolutely truthful women I have ever known, so she is equally one of the most unpersuadable! But once you get past the title, I find the book absolutely thrilling. A good deal of her journey across Russia she told me last winter with many interesting details which she omits here, but they were all of the same kind. I don't know whether a whole people is willing to live in such degrading filth and poverty for an idea or whether, against their will, they⬩W⬩S⬩C⬩ are forced to live like pigs because the Government took everything for the army and munitions. Fru Undset doesn't know, either. She doesn't pretend to explain it in conversation. She simply tells what she saw. She really had a jolly time in spite of all the dirt, and was so amused by two nice Princeton boys who had the compartment next hers on the \"luxury\" train to Vladivostok. They had got on the train believing all the fairy tales that American Communists tell them about \"efficiency\" in Russia. She always shared with them her sticks of chocolate, and every morning gave them a little mug of her precious store of bottled water to brush their teeth with.! You see, she had started from Sweden well provisioned with bottled water, chocolate, dried fish, etc. All the food on the train was either spoiled or full of dirt. One thing you may be sure of, Undset never exaggerates anything. As I say, there are some details of the disgusting conditions she encountered in Russia which simply could not be printed in this country. I am afraid for her, that there will be an awful row because she tells how much she admired Japan and such natives as she saw. I am telling her that I fear the women's clubs of the U.S.A. will come back at her. But they could not make her take back a line of her story if they put the thumb screws on her. Alfred Knopf and I would have liked to make some suggestions and to persuade her about the title, but neither of us was bold enough to do so. When I urged him to make suggestions about the title, he chuckled and said: \"Fine! You try first.\" Affectionately Willie"
+        },
+        "highlight" : {
+          "text" : [
+            " precious store of bottled <em>water</em> to brush their teeth with.! You see, she had started from Sweden well",
+            " provisioned with bottled <em>water</em>, chocolate, dried fish, etc. All the food on the train was either"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let2425",
+        "_score" : 3.296042,
+        "_source" : {
+          "identifier" : "cat.let2425",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to mary virginia boak cather, june 22 [1929]",
+          "title" : "Willa Cather to Mary Virginia Boak Cather, June 22 [1929]",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "June 22, 1929",
+          "date" : "1929-06-22",
+          "date_not_before" : "1929-06-22",
+          "date_not_after" : "1929-06-22",
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "University of Nebraska–Lincoln, Archives and Special Collections",
+          "rights_holder" : "University of Nebraska–Lincoln, Archives and Special Collections",
+          "person" : [
+            {
+              "name" : "Cather, Mary Virginia 'Jennie' Boak",
+              "id" : "0198",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Cather, Mary Virginia 'Jennie' Boak",
+              "id" : "0198"
+            },
+            {
+              "name" : "Mellen, Mary Virginia Auld",
+              "id" : "0044"
+            },
+            {
+              "name" : "Auld, Jessica Cather",
+              "id" : "0047"
+            },
+            {
+              "name" : "Auld, William Thomas 'Tom, Will'",
+              "id" : "0049"
+            },
+            {
+              "name" : "Auld, Charles",
+              "id" : "0045"
+            },
+            {
+              "name" : "Southwick, Helen Louise Cather",
+              "id" : "0872"
+            },
+            {
+              "name" : "Cather, Elsie",
+              "id" : "0187"
+            },
+            {
+              "name" : "Lewis, Edith",
+              "id" : "0560"
+            },
+            {
+              "name" : "Sherwood, Carrie Miner",
+              "id" : "0849"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Cather, Mary Virginia 'Jennie' Boak; Cather, Mary Virginia 'Jennie' Boak; Mellen, Mary Virginia Auld; Auld, Jessica Cather; Auld, William Thomas 'Tom, Will'; Auld, Charles; Southwick, Helen Louise Cather; Cather, Elsie; Lewis, Edith; Sherwood, Carrie Miner",
+          "keywords" : [ ],
+          "places" : [
+            "New York, New York, United States",
+            "Europe",
+            "Quebec, Canada",
+            "Grand Manan, New Brunswick, Canada"
+          ],
+          "works" : [ ],
+          "annotations" : "Studio portrait of Mary Virginia Boak Cather around the year 1900Philip L. and Helen Cather Southwick Collections, University of Nebraska-Lincoln Libraries Cather, Mary Virginia Boak (1850-1931) (“Virginia” or “Jenny”). Cather’s mother. Born in the Virginia to William Lee Boak and Rachel Seibert Boak, Virginia was educated in Baltimore, MD, and was a schoolteacher until her marriage to Charles Fectigue Cather in 1872. Her husband’s family were primarily Union supporters during the Civil War while her family supported the Confederacy (three brothers served in the Confederate Army although their mother opposed slavery). After her marriage she tried to help unite the divided family. Four of her children, Willa, Roscoe, Charles Douglas, and Jessica Virginia, were born in Virginia, while three, Jessica Virginia, James Donald, Elsie Margaret, and John Esten, were born in Nebraska after the family moved there in 1883. Despite occasional differences, Cather remained in affectionate contact with her mother, who remained in Red Cloud, NE, where the family settled in 1884. After her husband’s death in 1928 Virginia Cather suffered a stroke while visiting her children and their families in California. She spent nearly three years in a sanitarium in Pasadena, CA, unable to speak. Willa Cather visited her there several times but was unable to travel quickly enough from Grand Manan to Red Cloud for her funeral and interment after she died in Pasadena in 1931. Virginia Cather was the prototype for Victoria Templeton in “Old Mrs. Harris” (1932), which Willa Cather completed shortly before her mother’s death.Studio portrait of Mary Virginia Boak Cather around the year 1900Philip L. and Helen Cather Southwick Collections, University of Nebraska-Lincoln Libraries Cather, Mary Virginia Boak (1850-1931) (“Virginia” or “Jenny”). Cather’s mother. Born in the Virginia to William Lee Boak and Rachel Seibert Boak, Virginia was educated in Baltimore, MD, and was a schoolteacher until her marriage to Charles Fectigue Cather in 1872. Her husband’s family were primarily Union supporters during the Civil War while her family supported the Confederacy (three brothers served in the Confederate Army although their mother opposed slavery). After her marriage she tried to help unite the divided family. Four of her children, Willa, Roscoe, Charles Douglas, and Jessica Virginia, were born in Virginia, while three, Jessica Virginia, James Donald, Elsie Margaret, and John Esten, were born in Nebraska after the family moved there in 1883. Despite occasional differences, Cather remained in affectionate contact with her mother, who remained in Red Cloud, NE, where the family settled in 1884. After her husband’s death in 1928 Virginia Cather suffered a stroke while visiting her children and their families in California. She spent nearly three years in a sanitarium in Pasadena, CA, unable to speak. Willa Cather visited her there several times but was unable to travel quickly enough from Grand Manan to Red Cloud for her funeral and interment after she died in Pasadena in 1931. Virginia Cather was the prototype for Victoria Templeton in “Old Mrs. Harris” (1932), which Willa Cather completed shortly before her mother’s death.Mary Virginia on a visit to Cather and Lewis's Grand Manan cottege in 1933Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Mellen, Mary Virginia Auld (1906-1982) (“Virginia,” “M.V.”). Cather's niece. Born in Red Cloud, NE, to Jessica Cather Auld and James William Auld, Mary Virginia graduated from Red Cloud High School in 1924 and then spent a year at Dana Hall in Wellesley, MA, to qualify for admission to Smith College in Northampton, MA. In 1929 she received an A.B. in psychology from Smith and then moved to New York City, where she found work at Lord & Taylor before telling her aunt of her arrival. In 1930, probably with Willa Cather's help, she secured a position in the Circulation Department of the New York Public Library. In 1931, she entered the library's internal training school and in 1932 was assigned to the Tremont branch library in the Bronx. After Mary Virginia’s parents divorced in 1933 Cather took a quasi-parental role. She paid for vacations and when, in 1935, Mary Virginia married Richard (Dick) Mellen, a graduate of Harvard Medical School and roommate of her brother William Thomas Auld at Amherst College, she supervised wedding arrangements. After Dick was commissioned as a doctor in the Air Force, Mary Virginia—much to Cather’s regret—accompanied him to Chattanooga, TN, where he was assigned. In Cather's will, Mary Virginia was designated a beneficiary of the literary estate.Auld, Jessica Virginia Cather (1881-1964) (“Jessie”). Cather’s sister. Born in Virginia and raised in Red Cloud, NE, Jessica was the fourth child and second daughter of Charles and Virginia Cather. After graduating from Red Cloud High School in 1899, she taught at a country school and the South Side Grade School until her marriage to James William Auld, a Red Cloud banker, in 1904. They had three children (Charles, William Thomas, and Mary Virginia). After their divorce in 1933, she moved to Palo Alto, CA, where she died thirty-one years later. Few letters from Willa Cather to her sister Jessica survive, and particularly after Jessica’s divorce their relationship was strained.No annotation is availableNo annotation is availableSouthwick, Helen Louise Cather (1918-2004). Cather’s niece. Helen was born in Red Cloud, NE, to Willa Cather’s brother James and his wife Ethel. Willa was a doting aunt on her visits to Red Cloud. In 1931, Helen moved with her family to Long Beach, CA, where she graduated high school and attended Long Beach City College. In 1939, Helen returned to Red Cloud to help care for her maternal grandmother and then enrolled in the University of Nebraska in Lincoln, where she met her future husband, Philip Southwick. After graduating in 1941, she briefly returned to California to work in the personnel department of Douglas Aircraft company, but married Southwick in Lincoln in 1942, and then moved with him to Champagne, IL. When Philip’s employment took them to Plainfield, NJ, she frequently spent time with her aunt in New York City. In 1946, the Southwicks moved to Pittsburgh, PA, where their son James was born. In later years Helen worked as a school librarian and was active in the Cather Foundation in Red Cloud, NE. She was a beneficiary of Cather’s literary estate, and when Edith Lewis died in 1972 she bequeathed Cather books and manuscripts to Helen and her brother Charles Cather. Helen donated her share of these materials and Willa Cather’s letters to her to the University of Nebraska-Lincoln.A studio portrait of Elsie Margaret Cather Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Cather, Elsie Margaret (1890-1964) (“Bobbie”). Cather’s sister. Born in Red Cloud, NE, shortly before Willa Cather graduated from high school, Elsie attended the University of Nebraska in Lincoln from 1908 to 1910, before transferring to Smith College, in Northampton, MA, from which she graduated with an A.B. in English and Latin in 1912. She undertook graduate study at the University of Nebraska in 1914 and in 1916 received her A.M. with a major in philosophy and a minor in English. At both the undergraduate and the graduate level at Nebraska, she studied under Louise Pound. She began a career in high school teaching in 1912, when she took a position in Lander, WY, where her brother Roscoe then lived with his family. She also taught in Albuquerque, NM; Corning, IA; Cleveland, OH; and briefly Red Cloud, when illness in the family brought her home. Her longest tenure as a teacher was at Lincoln (NE) High School, where she began teaching in 1920, with Olivia Pound and Mariel Gere as colleagues. Willa Cather's expectation that Elsie be responsible for aging family and friends and for legal affairs after their parents' deaths sometimes brought the sisters into conflict. Elsie Cather retired from Lincoln High School in 1942. She died in Lincoln.Edith Lewis in the 1920sCharles E. Cather Collection, University of Nebraska-Lincoln Libraries Lewis, Edith Labaree (1881-1972). Magazine editor, advertising copywriter, and Cather's domestic partner. Born in Lincoln, NE, to Henry Euclid Lewis and Lillie Gould Lewis, Edith Lewis attended the preparatory school associated with the University of Nebraska, earning college credits from the University before transferring to Smith College in Northampton, MA, in 1899. She received an A.B. in English from Smith in 1902 and returned home to teach elementary school. She met Willa Cather in the summer of 1903 at the home of Sarah Harris, publisher of the Lincoln Courier. Moving to New York City soon afterward, Lewis settled into a studio on Washington Square and found work at the Century Publishing Company. Cather was her guest when she visited the city from Pittsburgh. In 1906, at Cather's suggestion, Lewis applied for a position as an editorial proofreader at McClure's Magazine, and the two women worked together on the McClure's staff for six years. In 1908, they moved into a shared apartment at 82 Washington Place, and then, in 1912, to Five Bank Street. Lewis left McClure's in 1915 to become managing editor of Every Week Magazine, where she stayed until the magazine folded in 1918. In 1919 she began a long career as an advertising copywriter at the J. Walter Thompson Co. In 1926 Edith Lewis acquired the land on which she and Cather built their cottage on Grand Manan Island. When they lost their apartment on Bank Street to subway construction in 1927, they shared quarters at the Grosvenor Hotel when they were both in New York City. In 1932 they took an apartment at 570 Park Avenue. Throughout their relationship, Lewis was closely involved in Cather's creative process, reading and editing her work in pre-publication forms. Cather's will appointed Lewis as executor of her literary estate and a beneficiary of her literary trust. Lewis authorized E.K. Brown as Cather's first biographer and published her own memoir of Cather, Willa Cather Living (1953). She remained in their Park Avenue apartment after Cather's death and died there after a long period of illness and invalidism. She is buried at Cather's side in Jaffrey, NH.Sherwood, Carrie Miner (1869-1971). Cather’s childhood friend. Carrie was the eldest daughter of James and Julia Miner, neighbors of the Cathers in Red Cloud, NE. Carrie was the prototype for Frances Harling in My Ántonia (1918). She was married to Red Cloud banker Walter Sherwood and was Willa Cather’s lifelong friend and correspondent.",
+          "text" : "VIRTUS NON STEMMAThe Grosvenor35 FIFTH AVENUENew York June 22 Dearest Mother; I was royally treated at Yale, but of course got home very tired. Mary Virginia and her party sailed last night at midnight. She ran in to see me in the morning yesterday, looking very pretty in a pale green dress and hat, and very much excited about her first sea voyage. She is only allowed to take two suit cases [suitcases] for baggage, so she can't take a very large supply of dresses, especially as she has to carry Kotex and hot water bottles in her suit cases. The total cost of the trip is $750, and they will run over nearly all Europe, so that means that she won't travel in luxury, which is all the better. Jess and Tom and Charles are in town. I will try to call on them tomorrow, but that is all I can do as I am hurrying off to Quebec Tuesday night to get some facts for my stoy story. My English publisher is in town and I am so busy that I have had to call off my appointment with my dentist and will go away with a sore tooth. Wasn't that a dear little letter from Helen Louise, all about their plays and lemonade stand? I really love her letters, she never tries to show off and she tells what one wants to know. Tell Elsie I do thank her for the cretonne—Edith thinks it will be lovely for Grand Manan. I have sent my beautiful new Yale collar to Carrie Sherwood to keep in her spare closet. With my dearest love to you, darling mother. Willie"
+        },
+        "highlight" : {
+          "text" : [
+            " Kotex and hot <em>water</em> bottles in her suit cases. The total cost of the trip is $750, and they will"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let0057",
+        "_score" : 3.0208108,
+        "_source" : {
+          "identifier" : "cat.let0057",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to mariel gere, august 2, 1899",
+          "title" : "Willa Cather to Mariel Gere, August 2, 1899",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "August 2, 1899",
+          "date" : "1899-08-02",
+          "date_not_before" : "1899-08-02",
+          "date_not_after" : "1899-08-02",
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "Nebraska State Historical Society, Lincoln, NE",
+          "rights_holder" : "Nebraska State Historical Society, Lincoln, NE",
+          "person" : [
+            {
+              "name" : "Gere, Mariel",
+              "id" : "0369",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Gere, Mariel",
+              "id" : "0369"
+            },
+            {
+              "name" : "Fisher, Dorothy Canfield",
+              "id" : "0311"
+            },
+            {
+              "name" : "Cather, Mary Virginia 'Jennie' Boak",
+              "id" : "0198"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Gere, Mariel; Gere, Mariel; Fisher, Dorothy Canfield; Cather, Mary Virginia 'Jennie' Boak",
+          "keywords" : [ ],
+          "places" : [
+            "Vladivostok, Russia",
+            "Lincoln, Nebraska, United States"
+          ],
+          "works" : [ ],
+          "annotations" : "Gere, Mariel Clapham (1874-1960). Cather’s university friend; a teacher. Mariel Gere, eldest daughter of Charles H. and Mariel C. Gere, born in Lincoln, NE, entered the University of Nebraska's prep school in the same year Cather did. She and her sisters visited Cather several times in Red Cloud, NE. Both were members of the Union Literary Society until Gere joined the Kappa Kappa Gamma sorority in 1892. Gere graduated in the science course and taught chemistry at Lincoln High until 1941. She also served on the Lincoln City Library board for many years. Cather and Gere remained friends and correspondents; Gere defended Cather from accusations that she had been arrogant and friendless during her university years.Gere, Mariel Clapham (1874-1960). Cather’s university friend; a teacher. Mariel Gere, eldest daughter of Charles H. and Mariel C. Gere, born in Lincoln, NE, entered the University of Nebraska's prep school in the same year Cather did. She and her sisters visited Cather several times in Red Cloud, NE. Both were members of the Union Literary Society until Gere joined the Kappa Kappa Gamma sorority in 1892. Gere graduated in the science course and taught chemistry at Lincoln High until 1941. She also served on the Lincoln City Library board for many years. Cather and Gere remained friends and correspondents; Gere defended Cather from accusations that she had been arrogant and friendless during her university years.Gere, Mariel Clapham (1874-1960). Cather’s university friend; a teacher. Mariel Gere, eldest daughter of Charles H. and Mariel C. Gere, born in Lincoln, NE, entered the University of Nebraska's prep school in the same year Cather did. She and her sisters visited Cather several times in Red Cloud, NE. Both were members of the Union Literary Society until Gere joined the Kappa Kappa Gamma sorority in 1892. Gere graduated in the science course and taught chemistry at Lincoln High until 1941. She also served on the Lincoln City Library board for many years. Cather and Gere remained friends and correspondents; Gere defended Cather from accusations that she had been arrogant and friendless during her university years.Fisher, Dorothy Canfield (1879-1958). American novelist; educational and social reformer. Dorothy Canfield and Willa Cather became friends in 1891 at the University of Nebraska in Lincoln, where Canfield's father, James Canfield, had come to serve as Chancellor. The family moved to Columbus, OH, in 1895 when James Canfield assumed the presidency of Ohio State University, from which Dorothy graduated in 1899. She then followed her father to New York City, where he became Librarian of Columbia University, and she pursued graduate study in Romance Languages at the University of Paris and Columbia, from which she earned a Ph.D. in 1904. On Cather’s first trip to Europe, she spent time in France and England with Canfield, including an awkward visit to the home of poet A.E. Housman. Cather derived the central character of “The Profile” (1907) from Canfield’s friend Evelyn Osborne, whom Cather had met in Europe. Cather and Canfield became estranged for more than a decade because Canfield objected to the story’s planned inclusion in The Troll Garden (1905). Canfield married John Redwood Fisher in 1907, and their primary residence was Arlington, VT. Canfield Fisher had spent 1916-1918 in France engaging in war relief work, and Cather’s consultation with her about the accuracy of her depiction of wartime France in One of Ours (1922) led them to reconcile. In 1925 Canfield Fisher became a founding member of the Book of the Month Club selection committee. She published her novels (most of them very popular) under the name Dorothy Canfield but her various nonfiction works as Dorothy Canfield Fisher.Studio portrait of Mary Virginia Boak Cather around the year 1900Philip L. and Helen Cather Southwick Collections, University of Nebraska-Lincoln Libraries Cather, Mary Virginia Boak (1850-1931) (“Virginia” or “Jenny”). Cather’s mother. Born in the Virginia to William Lee Boak and Rachel Seibert Boak, Virginia was educated in Baltimore, MD, and was a schoolteacher until her marriage to Charles Fectigue Cather in 1872. Her husband’s family were primarily Union supporters during the Civil War while her family supported the Confederacy (three brothers served in the Confederate Army although their mother opposed slavery). After her marriage she tried to help unite the divided family. Four of her children, Willa, Roscoe, Charles Douglas, and Jessica Virginia, were born in Virginia, while three, Jessica Virginia, James Donald, Elsie Margaret, and John Esten, were born in Nebraska after the family moved there in 1883. Despite occasional differences, Cather remained in affectionate contact with her mother, who remained in Red Cloud, NE, where the family settled in 1884. After her husband’s death in 1928 Virginia Cather suffered a stroke while visiting her children and their families in California. She spent nearly three years in a sanitarium in Pasadena, CA, unable to speak. Willa Cather visited her there several times but was unable to travel quickly enough from Grand Manan to Red Cloud for her funeral and interment after she died in Pasadena in 1931. Virginia Cather was the prototype for Victoria Templeton in “Old Mrs. Harris” (1932), which Willa Cather completed shortly before her mother’s death.",
+          "text" : "Aug 1899 about my going to Europe with the Canfields on her way to be with her sick mother in Lincoln Miss Mariel C. Gere D & Ninth Street Lincoln Nebraska MACKINAC ISLAND MICH. AUG 3 1899 8 PM NORTHERN STEAMSHIP CO.S. S. NORTH LAND. N. NEBR. REC'D. AUG 5 99 11 AM NORTHERN STEAMSHIP CO.GREAT NORTHERN RY. LINE.S. S. NORTH LAND. August 2/99My Dearest Mariel; I think you are about the luckiest girl I know and only the awful vows of secrecy to which Dorothy swore me, prevented me from writing you so at once. I am so glad about it all, my dear, it's like a dream come true. I am journeying home slowly by the Great Lake route, about a thousand miles by water and a day at Mackinac. I will be in Lincoln with Mother next Sunday at 139 N 12th Street, wherever that is. Mother has been ill there a long time you know, and while I am not exactly alarmed about her, I am very much worried. So I don't see how I can get a visit in with you, much as I'd love to. Every minute in Lincoln must be with Mother. But at any rate I'll get to see you before you start East, and that's something. Until Sunday Faithfully Willa"
+        },
+        "highlight" : {
+          "text" : [
+            " slowly by the Great Lake route, about a thousand miles by <em>water</em> and a day at Mackinac. I will be in"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let0785",
+        "_score" : 3.0208108,
+        "_source" : {
+          "identifier" : "cat.let0785",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to mrs. james mitchell, june 28 [1925]",
+          "title" : "Willa Cather to Mrs. James Mitchell, June 28 [1925]",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "June 28, 1925",
+          "date" : "1925-06-28",
+          "date_not_before" : "1925-06-28",
+          "date_not_after" : "1925-06-28",
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "Nebraska State Historical Society, Lincoln, NE",
+          "rights_holder" : "Nebraska State Historical Society, Lincoln, NE",
+          "person" : [
+            {
+              "name" : "Mitchell, Mrs. James",
+              "id" : "0670",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Mitchell, Mrs. James",
+              "id" : "0670"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Mitchell, Mrs. James; Mitchell, Mrs. James",
+          "keywords" : [ ],
+          "places" : [
+            "Alcalde, New Mexico, United States",
+            "Buffalo, New York, United States"
+          ],
+          "works" : [ ],
+          "annotations" : "No annotation is availableNo annotation is availableNo annotation is available",
+          "text" : "Image of La Fonda Hotel in Santa Fe, New Mexico LA FONDA HOTEL, SANTA FE, NEW MEXICO. June 28 My Dear Mrs. Mitchell: I’m travelling and simply can’t answer letters just now. Please excuse me. I hasten to tell you, though, that I won’t be giving any lectures next winter. Sincerely yours Willa Cather \"La Fonda\"At the End of the TrailPicturesquely built in the SpanishPueblo type, by the faith and vision ofSanta Fe; luxuriously, beautifully furn-ished after the Spanish period; a hotel deluxe that is different; of rare, artisticbeauty and historic interest, with everymodern comfort and convenience. Fromits restful rooms the casements look outupon the romantic old Plaza of Santa fe.This hotel is a home for the tourist,commercial people, and permanent guests.Plenty of rooms with private baths—telephone, hot and cold water in everyroom. You can make no mistake whenyou stop at La Fonda—European Plan.Excellent Cafe service.RATES—ONE PERSON$2.00—Up POST CARD (OVER) Mrs. James Mitchell 29 The Circle Buffalo New York ALCALDE N. MEX. JUN 30 1925"
+        },
+        "highlight" : {
+          "text" : [
+            "—telephone, hot and cold <em>water</em> in everyroom. You can make no mistake whenyou stop at La Fonda—European"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let1320",
+        "_score" : 3.0208108,
+        "_source" : {
+          "identifier" : "cat.let1320",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to ferris greenslet, july 24 [1936]",
+          "title" : "Willa Cather to Ferris Greenslet, July 24 [1936]",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "July 24, 1936",
+          "date" : "1936-07-24",
+          "date_not_before" : "1936-07-24",
+          "date_not_after" : "1936-07-24",
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "Harvard University, Houghton Library",
+          "rights_holder" : "Harvard University, Houghton Library",
+          "person" : [
+            {
+              "name" : "Greenslet, Ferris",
+              "id" : "0401",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Greenslet, Ferris",
+              "id" : "0401"
+            },
+            {
+              "name" : "Shannon, Margaret Cather",
+              "id" : "0197"
+            },
+            {
+              "name" : "Hambourg, Isabelle McClung",
+              "id" : "0418"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Greenslet, Ferris; Greenslet, Ferris; Shannon, Margaret Cather; Hambourg, Isabelle McClung",
+          "keywords" : [ ],
+          "places" : [
+            "Grand Manan, New Brunswick, Canada",
+            ""
+          ],
+          "works" : [ ],
+          "annotations" : "Ferris Greenslet's 1921 passport photo.The National Archives Greenslet, Ferris (1875-1959). American editor and writer. Born in Glens Falls, NY, Ferris Greenslet earned a B.A. (1897) from Wesleyan University and a Ph.D. (1900) from Columbia University. After serving as associate editor at the Atlantic Monthly from 1902 to 1907, Greenslet became literary editor at Houghton Mifflin in Boston, MA, where he championed Willa Cather’s early novels. As an author he specialized in biography. He was socially and professionally acquainted with Cather’s friends Annie Adams Fields and Sarah Orne Jewett, who may have introduced her to him in 1908. He became a director of Houghton Mifflin in 1919 and manager of the trade department in 1933. Greenslet and Cather’s correspondence provides many insights into Cather’s career. Although Cather left Houghton Mifflin as a publisher because she became dissatisfied with the production and advertising of her books, she remained on cordial terms with Greenslet.Ferris Greenslet's 1921 passport photo.The National Archives Greenslet, Ferris (1875-1959). American editor and writer. Born in Glens Falls, NY, Ferris Greenslet earned a B.A. (1897) from Wesleyan University and a Ph.D. (1900) from Columbia University. After serving as associate editor at the Atlantic Monthly from 1902 to 1907, Greenslet became literary editor at Houghton Mifflin in Boston, MA, where he championed Willa Cather’s early novels. As an author he specialized in biography. He was socially and professionally acquainted with Cather’s friends Annie Adams Fields and Sarah Orne Jewett, who may have introduced her to him in 1908. He became a director of Houghton Mifflin in 1919 and manager of the trade department in 1933. Greenslet and Cather’s correspondence provides many insights into Cather’s career. Although Cather left Houghton Mifflin as a publisher because she became dissatisfied with the production and advertising of her books, she remained on cordial terms with Greenslet.Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Studio portrait of Isabelle McClung HambourgPhilip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Hambourg, Isabelle McClung (1877-1938). Cather’s longtime friend. Cather met Isabelle McClung, the daughter of a socially prominent, Pittsburgh (PA) family, in 1899 in the dressing room of actress Lizzie Hudson Collier. McClung seems to have been the first woman to reciprocate Cather’s romantic affections. In 1901, McClung invited Cather to live in her family’s large home in the Squirrel Hill neighborhood of Pittsburgh. She and Cather traveled together to Europe in 1902, and McClung accompanied Cather on a visit home to Nebraska in 1905. After Cather moved to New York City in 1906, she frequently visited McClung in Pittsburgh, finding the familiar house a congenial place to write, and McClung visited New York City, staying with Cather and Edith Lewis. Cather and McClung also rented a vacation cabin in Cherry Valley, NY, in 1911, and traveled together to Virginia in 1913. In late 1915, shortly after the death of her father, Judge Samuel McClung, Isabelle announced her intention to marry violinist Jan Hambourg. Cather reacted negatively to the marriage (which took place in 1916) but eventually reconciled herself to it, enjoying long visits with the Hambourgs in Toronto, Ontario, in 1921 and France in 1923 and 1935. Isabelle’s death in Italy from kidney disease, which came only four months after Cather’s brother Douglass died, left her feeling bereft. “No other living person cared as much about my work, through thirty-eight years,” she wrote her brother Roscoe (#2137). After Isabelle’s death, Jan sent to Cather the three hundred letters from Cather to Isabelle in his possession, and Cather destroyed them.",
+          "text" : "FG Grand Manan July 24 Dear F. G.: When your letter came here I was taking a trip with two little nieces from Wyoming who have never seen salt water before. I am shocked to hear of your accident. A rock in the Connecticut river you say: fishing? But is there any fishing in that river? Perhaps your motor car plunged into the river—otherwise I can't see how you managed it. Anyhow I'm awfully sorry you had mischances. No, I don't think there will be another book for a year or two. I have one half-finished, but the long break of Mrs. Hambourg's illness and my stay abroad put it on the shelf. I lost interest in it, and shan't take it up until some turn of the wheel quickens my enthusiasm for it again. Sometime you must send me a volume of the size you have in mind for the set. My edition of the Thistle Stevenson (not autographed) seems to me just the right size book to hold comfortably. Surely you don't mean that I am to autograph each volume in this edition! You said something about an edition of twelve thousand sets, if I remember. Even twelve thousand autographs would be a pretty dreary job! Faithfully yours Willa Cather"
+        },
+        "highlight" : {
+          "text" : [
+            " nieces from Wyoming who have never seen salt <em>water</em> before. I am shocked to hear of your accident. A"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let1956",
+        "_score" : 2.8658073,
+        "_source" : {
+          "identifier" : "cat.let1956",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to mary virginia boak cather, august 12 [1920]",
+          "title" : "Willa Cather to Mary Virginia Boak Cather, August 12 [1920]",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "August 12, 1920",
+          "date" : "1920-08-12",
+          "date_not_before" : "1920-08-12",
+          "date_not_after" : "1920-08-12",
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "University of Nebraska-Lincoln, Archives and Special Collections, Lincoln, NE",
+          "rights_holder" : "University of Nebraska-Lincoln, Archives and Special Collections, Lincoln, NE",
+          "person" : [
+            {
+              "name" : "Cather, Mary Virginia 'Jennie' Boak",
+              "id" : "0198",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Cather, Mary Virginia 'Jennie' Boak",
+              "id" : "0198"
+            },
+            {
+              "name" : "Lewis, Edith",
+              "id" : "0560"
+            },
+            {
+              "name" : "Hambourg, Isabelle McClung",
+              "id" : "0418"
+            },
+            {
+              "name" : "Hambourg, Jan",
+              "id" : "0419"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Cather, Mary Virginia 'Jennie' Boak; Cather, Mary Virginia 'Jennie' Boak; Lewis, Edith; Hambourg, Isabelle McClung; Hambourg, Jan",
+          "keywords" : [ ],
+          "places" : [
+            "Cavalière, Provence-Alpes-Côte d'Azur,\n                            France",
+            "France",
+            "Mediterranean Sea",
+            "Italy",
+            "Paris, Île-de-France, France"
+          ],
+          "works" : [ ],
+          "annotations" : "Studio portrait of Mary Virginia Boak Cather around the year 1900Philip L. and Helen Cather Southwick Collections, University of Nebraska-Lincoln Libraries Cather, Mary Virginia Boak (1850-1931) (“Virginia” or “Jenny”). Cather’s mother. Born in the Virginia to William Lee Boak and Rachel Seibert Boak, Virginia was educated in Baltimore, MD, and was a schoolteacher until her marriage to Charles Fectigue Cather in 1872. Her husband’s family were primarily Union supporters during the Civil War while her family supported the Confederacy (three brothers served in the Confederate Army although their mother opposed slavery). After her marriage she tried to help unite the divided family. Four of her children, Willa, Roscoe, Charles Douglas, and Jessica Virginia, were born in Virginia, while three, Jessica Virginia, James Donald, Elsie Margaret, and John Esten, were born in Nebraska after the family moved there in 1883. Despite occasional differences, Cather remained in affectionate contact with her mother, who remained in Red Cloud, NE, where the family settled in 1884. After her husband’s death in 1928 Virginia Cather suffered a stroke while visiting her children and their families in California. She spent nearly three years in a sanitarium in Pasadena, CA, unable to speak. Willa Cather visited her there several times but was unable to travel quickly enough from Grand Manan to Red Cloud for her funeral and interment after she died in Pasadena in 1931. Virginia Cather was the prototype for Victoria Templeton in “Old Mrs. Harris” (1932), which Willa Cather completed shortly before her mother’s death.Studio portrait of Mary Virginia Boak Cather around the year 1900Philip L. and Helen Cather Southwick Collections, University of Nebraska-Lincoln Libraries Cather, Mary Virginia Boak (1850-1931) (“Virginia” or “Jenny”). Cather’s mother. Born in the Virginia to William Lee Boak and Rachel Seibert Boak, Virginia was educated in Baltimore, MD, and was a schoolteacher until her marriage to Charles Fectigue Cather in 1872. Her husband’s family were primarily Union supporters during the Civil War while her family supported the Confederacy (three brothers served in the Confederate Army although their mother opposed slavery). After her marriage she tried to help unite the divided family. Four of her children, Willa, Roscoe, Charles Douglas, and Jessica Virginia, were born in Virginia, while three, Jessica Virginia, James Donald, Elsie Margaret, and John Esten, were born in Nebraska after the family moved there in 1883. Despite occasional differences, Cather remained in affectionate contact with her mother, who remained in Red Cloud, NE, where the family settled in 1884. After her husband’s death in 1928 Virginia Cather suffered a stroke while visiting her children and their families in California. She spent nearly three years in a sanitarium in Pasadena, CA, unable to speak. Willa Cather visited her there several times but was unable to travel quickly enough from Grand Manan to Red Cloud for her funeral and interment after she died in Pasadena in 1931. Virginia Cather was the prototype for Victoria Templeton in “Old Mrs. Harris” (1932), which Willa Cather completed shortly before her mother’s death.Edith Lewis in the 1920sCharles E. Cather Collection, University of Nebraska-Lincoln Libraries Lewis, Edith Labaree (1881-1972). Magazine editor, advertising copywriter, and Cather's domestic partner. Born in Lincoln, NE, to Henry Euclid Lewis and Lillie Gould Lewis, Edith Lewis attended the preparatory school associated with the University of Nebraska, earning college credits from the University before transferring to Smith College in Northampton, MA, in 1899. She received an A.B. in English from Smith in 1902 and returned home to teach elementary school. She met Willa Cather in the summer of 1903 at the home of Sarah Harris, publisher of the Lincoln Courier. Moving to New York City soon afterward, Lewis settled into a studio on Washington Square and found work at the Century Publishing Company. Cather was her guest when she visited the city from Pittsburgh. In 1906, at Cather's suggestion, Lewis applied for a position as an editorial proofreader at McClure's Magazine, and the two women worked together on the McClure's staff for six years. In 1908, they moved into a shared apartment at 82 Washington Place, and then, in 1912, to Five Bank Street. Lewis left McClure's in 1915 to become managing editor of Every Week Magazine, where she stayed until the magazine folded in 1918. In 1919 she began a long career as an advertising copywriter at the J. Walter Thompson Co. In 1926 Edith Lewis acquired the land on which she and Cather built their cottage on Grand Manan Island. When they lost their apartment on Bank Street to subway construction in 1927, they shared quarters at the Grosvenor Hotel when they were both in New York City. In 1932 they took an apartment at 570 Park Avenue. Throughout their relationship, Lewis was closely involved in Cather's creative process, reading and editing her work in pre-publication forms. Cather's will appointed Lewis as executor of her literary estate and a beneficiary of her literary trust. Lewis authorized E.K. Brown as Cather's first biographer and published her own memoir of Cather, Willa Cather Living (1953). She remained in their Park Avenue apartment after Cather's death and died there after a long period of illness and invalidism. She is buried at Cather's side in Jaffrey, NH.Studio portrait of Isabelle McClung HambourgPhilip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Hambourg, Isabelle McClung (1877-1938). Cather’s longtime friend. Cather met Isabelle McClung, the daughter of a socially prominent, Pittsburgh (PA) family, in 1899 in the dressing room of actress Lizzie Hudson Collier. McClung seems to have been the first woman to reciprocate Cather’s romantic affections. In 1901, McClung invited Cather to live in her family’s large home in the Squirrel Hill neighborhood of Pittsburgh. She and Cather traveled together to Europe in 1902, and McClung accompanied Cather on a visit home to Nebraska in 1905. After Cather moved to New York City in 1906, she frequently visited McClung in Pittsburgh, finding the familiar house a congenial place to write, and McClung visited New York City, staying with Cather and Edith Lewis. Cather and McClung also rented a vacation cabin in Cherry Valley, NY, in 1911, and traveled together to Virginia in 1913. In late 1915, shortly after the death of her father, Judge Samuel McClung, Isabelle announced her intention to marry violinist Jan Hambourg. Cather reacted negatively to the marriage (which took place in 1916) but eventually reconciled herself to it, enjoying long visits with the Hambourgs in Toronto, Ontario, in 1921 and France in 1923 and 1935. Isabelle’s death in Italy from kidney disease, which came only four months after Cather’s brother Douglass died, left her feeling bereft. “No other living person cared as much about my work, through thirty-eight years,” she wrote her brother Roscoe (#2137). After Isabelle’s death, Jan sent to Cather the three hundred letters from Cather to Isabelle in his possession, and Cather destroyed them.Portrait of Jan Hambourg taken by Fizin in New YorkNebraska State Historical Society Hambourg, Jan (1882-1947). Russian-born violinist; Isabelle McClung’s husband. Hambourg moved with his family to Toronto, Ontario, in 1910, where he was the head of the violin department at the Hambourg Conservatory and performed as part of the Hambourg Trio. He married Isabelle McClung in April 1916. Cather reacted negatively to both Hambourg and the marriage, but she gradually came to accept him. Beginning in the 1920s, Hambourg left the family conservatory and focused on solo violin performance in Europe. Cather enjoying long visits with Isabelle and Jan in Toronto in 1921 and France in 1923 and 1935. She dedicated The Professor’s House (1925) to him (“For Jan, because he likes narrative”) and asked him to make musical corrections to Lucy Gayheart (1935). When Isabelle died, Jan sent to Cather the three hundred letters from Cather to Isabelle in his possession, and Cather destroyed them.",
+          "text" : "August 12 Dearest Mother: I am writing from a small fishing village on the south coast of France, right on the Mediterranean sea. The last few weeks have been confused ones. Six weeks ago Edith Lewis went on to the south of Italy, and three weeks ago I left Paris and came south with Isabelle and her husband for an interesting but rather hard trip in the old cities of the South of France. We had just got nicely started when I fell ill and upset all our plans. The Hambourgs were so kind about having their trip spoiled, and came right down to this quiet, restful place on the sea where I would get better and where they could spend hours in the sea every day. Isabelle is a good swimmer and loves the water. Last week I was to have left Isabelle and Jan and gone on down to Italy to join Edith. But poor Edith writes that the food shortage in Italy has grown more serious every day. She cannot get enough to eat, no matter what she pays. She can never get enough bread, and can get no milk, butter, sugar, cakes or sweets of any kind! So now Edith will have to journey all the way back to France and we will all go to Paris together. Paris is the only place where one can still be as comfortable as before the war. I shall not go to Italy at all, but wilL sail from the north of France as soon as I can get a boat. It may be a month or six weeks before I can get a boat, as almost everyone is trying to get home now. I am tired of poor food myself, and I wish I could get into the kitchen at home and roast a chicken and make a pie! The food in Paris is delicious, but down here the country has not recovered from the war and provisions are scarce. Goodbye, darling mother. Isabelle sends you her best love. Willie P.S. Although I was the one who felt the worst, none of us have been very well down here. Isabelle is languid most of the time, too. I don't know why, for the climate is beautiful. Jan is a wonderful man to travel with—never cross about anything. I don't see how a man can be so patient!"
+        },
+        "highlight" : {
+          "text" : [
+            " the <em>water</em>. Last week I was to have left Isabelle and Jan and gone on down to Italy to join Edith"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let2341",
+        "_score" : 2.8658073,
+        "_source" : {
+          "identifier" : "cat.let2341",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to elizabeth cather and margaret cather, [august 1937]",
+          "title" : "Willa Cather to Elizabeth Cather and Margaret Cather, [August 1937]",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "N.D.",
+          "date" : null,
+          "date_not_before" : null,
+          "date_not_after" : null,
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "University of Nebraska–Lincoln, Archives and Special Collections",
+          "rights_holder" : "University of Nebraska–Lincoln, Archives and Special Collections",
+          "person" : [
+            {
+              "name" : "Shannon, Margaret Cather",
+              "id" : "0197",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Shannon, Margaret Cather",
+              "id" : "0197"
+            },
+            {
+              "name" : "Ickis, Elizabeth Cather",
+              "id" : "0185"
+            },
+            {
+              "name" : "Beal, Ralph L.",
+              "id" : "0079"
+            },
+            {
+              "name" : "Thomas, Willie",
+              "id" : "0920"
+            },
+            {
+              "name" : "Jacobus, Sarah Hayes",
+              "id" : "0479"
+            },
+            {
+              "name" : "Tennant, Stephen",
+              "id" : "0917"
+            },
+            {
               "name" : "",
-              "id" : ""
+              "id" : "psn"
             }
           ],
           "contributor" : [
             {
-              "name" : "Weakly, Laura K.",
-              "id" : "lkw",
-              "role" : null
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
             },
             {
-              "name" : "Tiedje, Michelle",
-              "id" : null,
-              "role" : null
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
             }
           ],
-          "creator" : [ ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Shannon, Margaret Cather; Shannon, Margaret Cather; Ickis, Elizabeth Cather; Beal, Ralph L.; Thomas, Willie; Jacobus, Sarah Hayes; Tennant, Stephen; ",
           "keywords" : [ ],
-          "places" : [ ],
+          "places" : [
+            "Grand Manan, New Brunswick, Canada",
+            "Montreal, Quebec, Canada",
+            "Casper, Wyoming, United States",
+            "Eastport, Maine, United States",
+            "Boston, Massachusetts, United\n                            States",
+            "Quebec, Canada",
+            "Colusa, California, United States",
+            "Aix-les-Bains, Rhône-Alpes, France"
+          ],
           "works" : [ ],
-          "annotations" : null,
-          "text" : "   Lincoln, Neb. Nov. 4, 1899. My dear Mr. Perkins,—  I returned this P. M. from the big horn basin. Mr. Calvert is of the opinion that an expert geologist should be sent to the basin to get more definite knowledge as to the coal proposition and as winter is near at hand, making immediate action necessary if anything is to be done this fall, I send my report of the trip. Before making this report I had expected to obtain further definite information from the irrigation commissioners and also from the state geologists of Wyoming. That, however, can come later if necessary. From Billings we drove direct to Pryor Gap. About 8 miles North of the gap we struct [sic] Pryor Creek. It is a small stream inside the Indian Reservation, and if this land should be brought into the market, the water running in the creek is only sufficient to irrigate a small strip of land on each side of the same. I talked with several of the me who surveyed the line from Toluca and they informed me there is nothing but a few small srpingssprings between Toluca and Pryor Creek. As all the country between Toluca and Pryor Gap is in the Indian Reservation, as long as the indians remain there, it will be nothing but a cattle country. It is about 8 miles from Pryor Gap into the basin. There is a small creek running South from the Gap called Sage Creek. It has only water enough to supply 6 or 7 farms and there is already litigation between the settlers living in Wyoming and those living in Montana. Between Pryor Gap and Frannie there are less than 10 houses. During the irrigating season there is no water running in Sage Creek South of Frannie; therefore, the litigation above referred to. From Frannie we drove South West across the Shoshone flats to Eagles Nest and thence to Cody. There is not a sign of habitation between Frannie and Cody, with the exception of a road house at Eagles' Nest and another at Corbit [sic] where the road crosses the Shoshone River. At Cody there are less than a dozen houses, and only one store. There is no water in Cody, even for the irrigation of gardens. The Cody ditch scheme has been a failure up to the present time. From Cody we went around Cedar Mountain and followed up Sulphur Creek as Cody claimed that was the garden of his scheme at the present time. West of Cedar Mountain there are a few settlers, I think less than 10. I asked several of those I met about the amount in cultivation and in figuring it up they all made it less than 600 acres. They said there had been more settlers there, but owing to the failure of the ditch to furnish water, they had become disgusted and left. Cody's ditch starts about 16 or 17 miles up the Shoshone River. There they have put in a head-gate. After coming down the valley four or five miles they have turned the water into Sulphur Creek. I think probably two or three thousand acres of land could be irrigated above Cody in the Shoshone Valley and along Sulphur Creek providing the ditch was kept in order. Before getting the water down to the town of Cody and out onto the flats, there are serious difficulties to surmount. In getting around Cedar Mountain there is about 1-1/2 miles of flume which is in bad condition at the present time, and I think always has been. Even if it was kept in good condition, the flume is only four feet wide by two feet high. As you will see by reference to your map, Cody has in his scheme many thousand acres East of his town. There is no question about the supply of water with a properly constructed ditch, but I should judge that it would cost at least $250,000 to construct a ditch of sufficient capacity to water the lands that have been segregated to the ditch scheme on the South side of the river. From Cody we drove East to Dry Creek and then down Dry Creek toward Burlington. There is a vast area of land that could be watered from the Shoshone River by running the ditch across from Cedar Mountain to the head of Dry Creek, then down the creek towards Burlington. As Dry Creek is a shallow ravine with large flats both East and West, the scheme is feasible. We followed down Dry Creek until within sight of Burlington and then turned South down the Greybull River. Here is Wiley's (of Omaha) scheme of irrigation. He has made considerable headway as it is easy to get the water out of the Greybull. Before he undertook to construct the ditch there were settlers scattered all along the Greybull River. We stopped over night with a Mr. Beck about 20 miles North West of Meteesee. Mr. Beck is a man of good judgment. He lived in Burt county Nebraska over thirty years and was a State Senator. He has lived at his present location six years, has 400 acres in alfalfa and is delighted with his new home. From this point, we run almost directly West to Cody in order to pass some coal prospects. From Cody we passed East of Heart Mountain across the Shoshone flats North to Bridger on Clark's Fork. From Bridger we went up the line of Rockfort Creek to Carbon and down where Daily (of the Aconda Copper mines) is taking out coal, making a total of about 300 miles that we drove. In the entire distance from Pryor Gap back to Bridger, we saw less than 100 houses including and Burlington, and not including Bridger and carbon [sic]. The soil in the basin is excellent; I think as good as the best Nebraska soil. That is proven by what is being produced on the small streams and springs referred to. Nearly every settler who lives on the stream has some alfalfa and is raising vegetables; although, I do not think they are producing as much in the basin as they are consuming at the present time. We found croppings of coal at various places, but it was all lignite and poor stuff that we saw or could hear of, except the coal at Bridger, Carbon and Red Lodge. At Bridger they have fifty men at work. The coal there is lignite, but of a very fair quality and is used for engine coal by the N. P. They go into the hill on a slant of about 22 degrees and the vein is about three feet thick. At Carbon, Dailey went down about 1000 feet before he shipped any coal. It took him a year to get ready and he has a vein about 3-1/2 feet thick. It is also lignite and poorer than the Bridger coal. We did not go up to Red Lodge, but they have 6 or 7 feet of coal there and work 500 men. It is also lignite, but the men on the road said it made fair engine coal. They are taking out coal about 10 miles West of Bowler (at the South end of Pryor Gap) and selling it to the ranchers. They claim to have five or six feet of lignite. They also clam to have a vein from 7 to 9 feet thick about half way between Cody and Meteesee. Down by Basin City, there are coal mines. In fact, there is no doubt, but what there is plenty of lignite coal, but there is serious doubt at the present time as to where you would find good coal. I should have said that just 4 miles West of Cody there is a very fine warm sulphur spring. It would undoubtedly become a resort if a railroad run nearby. If you should go up the Shoshone toward Yellowstone you would pass right by this spring. The scenery here is very fine — something on the order of the Grande Canon of Yellowstone Park (on a smaller scale). If you should build from Toluca South through Pryor Gap and stop at the nearest point where you could get coal, it would be on Bear Creek or Jack Creek about 10 miles West of Bowers. You would be obliged to make arrangements to get the water that comes down Sage Creek and pipe it down. The town would then be located in an arid country with no possibilities for irrigation, and simply be a coal mining town. The trade of the basin nearly all goes to Billings where their stocks of goodswould [sic] compare favorable with stocks in Lincoln or Omaha. In my opinion the class of merchants that would settle at a coal town in such a place as above mentioned, could not divert much of the trade from Billings. If you run down towards Burlington, it would make about 125 miles in all. In that case, you could get into a good country where parties who wanted to go into business would recognize that it was permanent. From that point, you could, by following up the Greybull, go into the Wood River country. As to the mines, we saw a man who was direct from the Sunlight country North of Cody, who said there was nothing substantial there at the present time. Parties in Cody said he was reliable. There were several veins opened where the ore was very rich, but in very small quantities. Mr. Calvert informs me that Mr. Holdrege has an expert in the Wood River Country so that you will get definite information from him. This is a wonderful country and will sometime be almost an empire of itself. Inside of the basin rim there is about 6,500,000 acres of land. I should say that it is possible to irrigate from 1,000,000 to 1,500,000 acres from the Shoshone, Greybull, Clark's Fork and numerous small streams. Supposing we call it 1,000,000 acres. That would leave five and a half million for pasturage. The soil is excellent; the grass is fine; and the climate is better for stock than another section of the NorthWest because of the light snow fall. There is a large number of cattle shipped in the basin. Nearly all the stock is driven to the B. & M. at the present time. Otto Franks, who owns Pitchford ranch, South and West of Meteesee drives to the B. & M. I met another ranchman about 40 miles West of Cody who had just driven 200 head to the B. & M.. He said he always shipped over that line because it was cheaper and shorter to market. In fact, every stockman I talked with on the entire trip said they shipped over the B. & M. Therefore, from that source, you can gain very little by going into the basin. I should like to talk this matter over with you as I can give you a very much better idea about what has been done in the way of irrigation and prospects for future movement in that direction. If you want to send a coal expert into that country, I think I can get Prof. Barbour of the State University, who is recognized as a true scientist and well up. Mr. Calvert thinks he would be a splendid man to send up there. If you think I had better run down to see you, let me know so that I can start Tuesday and get down there Wednesday. I have made arrangements to start for Guernsey's the 13th inst. I will say that it is my judgment that if you or Mr. Harris had been with us on the trip, you would decided that it is too early to go into that country. However, I am not a railroad man and there are many features of the situation that I know very little of. One thing is certain, that if you build the road there with the present conditions, it will be simply for coal. The stock trade you have at the present time. Undoubtedly your building in would stimulate various industries that are not there at the present time.  Yours truly, C. H. Morrill.   "
+          "annotations" : "Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Ickis, Elizabeth Cather (1915-1978) (half of the “twinnies”). Cather’s niece. Elizabeth and her twin sister Margaret were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them she often refers back to their summer visits as a magical time. Elizabeth moved to Colusa, CA, with her parents in 1937 and married Lynn S. Ickis, an electrical engineer, in April 1938. They lived in Detroit, MI, where their daughter Margaret was born in 1939, and Cleveland, OH, where son John was born in 1943.Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.No annotation is availableThomas, Willie. Grand Manan handy man. A year-round resident of Grand Manan Island, part of the province of New Brunswick, Canada, Willie Thomas worked as a handy man for Cather and Edith Lewis, helping to maintain their vacation cottage on the island.Jacobus, Sarah Hayes (1875-1948). Proprietor of the Whale Cove Inn, Grand Manan Island. An 1897 graduate of the Boston Normal School for Gymnastics, Sarah Jacobus \"discovered\" Grand Manan Island with two classmates in 1900, and in 1901 they purchased property at Whale Cove. By the time Willa Cather and Edith Lewis first visited Whale Cove in 1922, the summer colony had become an inn, with guests renting rooms in the main building or in adjacent cottages and taking meals in the inn's dining room. Jacobus was co-owner of the inn, and during the summer season she was in residence as the on-site manager. When summer visitors, including Cather and Lewis, built their own cottages, they continued to take meals in the dining room. In the off seasons from 1920 through 1932 Jacobus lived in Manhattan and worked in the Circulation Department of the New York Public Library. Later in her life, she lived year round on Grand Manan and died there.No annotation is available",
+          "text" : "Air Mail, Via Montreal From W. S. Cather WHALE COVEGRAND MANANNEW BRUNSWICKCANADA Margaret & Elizabeth Cather Hotel Hemming Casper Wyoming U. S. A. Tuesday My Darling Twinnies; Yesterday a wild northeaster—wish you could have seen it. Bitter cold, and breakers of black water pounding up on the Giants' Graves under a very low black–gray sky. Today, fair and dreanydreamy—all off on boat trips. I finished the autographs on Friday morning and sent them over to Eastport by special messenger (Ralph!) on Saturday boat. He bore himself like a King's messenger! Hadn't been to Eastport for years. We left the box in back hall, he came for it at six a.m. bore it off without waking us. Took it on boat as personal baggage, got it through American Customs, drove in a taxi to express office at the far end of Eastport, got it on the train for Boston. Such a proud man he was. Happy thought: if I take Ralph for my errand secretary, then perhaps we may have Willie for gardener? Willie went for Miss Jacobus to cut the alder thickets on the Dimple Downs with his double–edged ax. Ax rebounded from a dead alder and cut his knee to the bone. He walked home but was unable to work for some days—lost blood, of course, and such dirty clothes ribi rib rubbing it as he walked home! Inflammation gone, however, and the wound has healed. I was almost as much disappointed any as you, my dears, about your being shut out of the comfortable Frontenac. 3 I didn't realize that after prohibition it would be crowded. I should have written the Management two weeks before you went away, and demanded rooms as a personal favor. Ah, I wish you could see Quebec in Winter! I am sending a very interesting book on G. Manan on to Colusa. My hand is still stiff, as you can see—autographing didn't do it any good. I must get a note off to Stephen who cabled yesterday from Aix-les Bains to know where I am and whether I am ill. So now I must stop this letter. Everyone misses you, my dear children, but no one misses you so much as I do. Your very loving Aunt P. S. Oh delight! Yesterday Miss Bonnell telephoned Gannet Light keeper to ask if she might come to spend night first fair day. Keeper replied his wife away on visit for two weeks, and he was afraid Government Inspectors would not approve Bonnell's visit! These are the actual facts. She had engaged motor boat."
         },
         "highlight" : {
           "text" : [
-            " stream inside the Indian Reservation, and if this land should be brought into the market, the <em>water</em>",
-            " running South from the Gap called Sage Creek. It has only <em>water</em> enough to supply 6 or 7 farms and there",
-            " Pryor Gap and Frannie there are less than 10 houses. During the irrigating season there is no <em>water</em>"
+            " northeaster—wish you could have seen it. Bitter cold, and breakers of black <em>water</em> pounding up on the"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let1863",
+        "_score" : 2.854791,
+        "_source" : {
+          "identifier" : "cat.let1863",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to elsie cather, november 3 [1934]",
+          "title" : "Willa Cather to Elsie Cather, November 3 [1934]",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "November 3, 1934",
+          "date" : "1934-11-03",
+          "date_not_before" : "1934-11-03",
+          "date_not_after" : "1934-11-03",
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "University of Nebraska-Lincoln, Archives and Special Collections",
+          "rights_holder" : "University of Nebraska-Lincoln, Archives and Special Collections",
+          "person" : [
+            {
+              "name" : "Cather, Elsie",
+              "id" : "0187",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Cather, Elsie",
+              "id" : "0187"
+            },
+            {
+              "name" : "Cather, Charles F.",
+              "id" : "0180"
+            },
+            {
+              "name" : "Cather, Mary Virginia 'Jennie' Boak",
+              "id" : "0198"
+            },
+            {
+              "name" : "Morgan, J. P.",
+              "id" : "0682"
+            },
+            {
+              "name" : "Lewis, Edith",
+              "id" : "0560"
+            },
+            {
+              "name" : "Ferris, Mollie",
+              "id" : "0304"
+            },
+            {
+              "name" : "Huffman, Elizabeth M. 'Lizzie'",
+              "id" : "0465"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Cather, Elsie; Cather, Elsie; Cather, Charles F.; Cather, Mary Virginia 'Jennie' Boak; Morgan, J. P.; Lewis, Edith; Ferris, Mollie; Huffman, Elizabeth M. 'Lizzie'",
+          "keywords" : [ ],
+          "places" : [
+            "Jaffrey, New Hampshire, United\n                            States",
+            "New York, New York, United States"
+          ],
+          "works" : [ ],
+          "annotations" : "A studio portrait of Elsie Margaret Cather Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Cather, Elsie Margaret (1890-1964) (“Bobbie”). Cather’s sister. Born in Red Cloud, NE, shortly before Willa Cather graduated from high school, Elsie attended the University of Nebraska in Lincoln from 1908 to 1910, before transferring to Smith College, in Northampton, MA, from which she graduated with an A.B. in English and Latin in 1912. She undertook graduate study at the University of Nebraska in 1914 and in 1916 received her A.M. with a major in philosophy and a minor in English. At both the undergraduate and the graduate level at Nebraska, she studied under Louise Pound. She began a career in high school teaching in 1912, when she took a position in Lander, WY, where her brother Roscoe then lived with his family. She also taught in Albuquerque, NM; Corning, IA; Cleveland, OH; and briefly Red Cloud, when illness in the family brought her home. Her longest tenure as a teacher was at Lincoln (NE) High School, where she began teaching in 1920, with Olivia Pound and Mariel Gere as colleagues. Willa Cather's expectation that Elsie be responsible for aging family and friends and for legal affairs after their parents' deaths sometimes brought the sisters into conflict. Elsie Cather retired from Lincoln High School in 1942. She died in Lincoln.A studio portrait of Elsie Margaret Cather Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Cather, Elsie Margaret (1890-1964) (“Bobbie”). Cather’s sister. Born in Red Cloud, NE, shortly before Willa Cather graduated from high school, Elsie attended the University of Nebraska in Lincoln from 1908 to 1910, before transferring to Smith College, in Northampton, MA, from which she graduated with an A.B. in English and Latin in 1912. She undertook graduate study at the University of Nebraska in 1914 and in 1916 received her A.M. with a major in philosophy and a minor in English. At both the undergraduate and the graduate level at Nebraska, she studied under Louise Pound. She began a career in high school teaching in 1912, when she took a position in Lander, WY, where her brother Roscoe then lived with his family. She also taught in Albuquerque, NM; Corning, IA; Cleveland, OH; and briefly Red Cloud, when illness in the family brought her home. Her longest tenure as a teacher was at Lincoln (NE) High School, where she began teaching in 1920, with Olivia Pound and Mariel Gere as colleagues. Willa Cather's expectation that Elsie be responsible for aging family and friends and for legal affairs after their parents' deaths sometimes brought the sisters into conflict. Elsie Cather retired from Lincoln High School in 1942. She died in Lincoln.Portrait of Charles Fectigue CatherNebraska State Historical Society Cather, Charles Fectigue (1848-1928). Cather’s father. Charles Cather was born in the Back Creek Valley of Virginia, north of Winchester. His family were sheep raisers who were largely, but not entirely, Union supporters during the Civil War. He married Mary Virginia Sibert Boak, daughter of Confederate supporters, in 1872. In 1883 he and his family followed his parents, William and Caroline Cather, and brother George to Webster County in Nebraska, where various cousins and uncles had also settled. Initially he ran a ranch in the county but soon moved his family into the town of Red Cloud, where he had an insurance and real estate business. Four of his children, Willa, Roscoe, Charles, and Jessica, were born in Virginia, while three, James, Elsie, and John, were born in Nebraska. Cather’s relationship with her father was very warm: she made regular visits to her parents in Red Cloud and especially enjoyed her father’s letters expressing appreciation of her novels. A week after she concluded a visit to her ailing father in Red Cloud, he died of heart disease. He served as the prototype for Hillary Templeton in “Old Mrs. Harris” (1932).Studio portrait of Mary Virginia Boak Cather around the year 1900Philip L. and Helen Cather Southwick Collections, University of Nebraska-Lincoln Libraries Cather, Mary Virginia Boak (1850-1931) (“Virginia” or “Jenny”). Cather’s mother. Born in the Virginia to William Lee Boak and Rachel Seibert Boak, Virginia was educated in Baltimore, MD, and was a schoolteacher until her marriage to Charles Fectigue Cather in 1872. Her husband’s family were primarily Union supporters during the Civil War while her family supported the Confederacy (three brothers served in the Confederate Army although their mother opposed slavery). After her marriage she tried to help unite the divided family. Four of her children, Willa, Roscoe, Charles Douglas, and Jessica Virginia, were born in Virginia, while three, Jessica Virginia, James Donald, Elsie Margaret, and John Esten, were born in Nebraska after the family moved there in 1883. Despite occasional differences, Cather remained in affectionate contact with her mother, who remained in Red Cloud, NE, where the family settled in 1884. After her husband’s death in 1928 Virginia Cather suffered a stroke while visiting her children and their families in California. She spent nearly three years in a sanitarium in Pasadena, CA, unable to speak. Willa Cather visited her there several times but was unable to travel quickly enough from Grand Manan to Red Cloud for her funeral and interment after she died in Pasadena in 1931. Virginia Cather was the prototype for Victoria Templeton in “Old Mrs. Harris” (1932), which Willa Cather completed shortly before her mother’s death.No annotation is availableEdith Lewis in the 1920sCharles E. Cather Collection, University of Nebraska-Lincoln Libraries Lewis, Edith Labaree (1881-1972). Magazine editor, advertising copywriter, and Cather's domestic partner. Born in Lincoln, NE, to Henry Euclid Lewis and Lillie Gould Lewis, Edith Lewis attended the preparatory school associated with the University of Nebraska, earning college credits from the University before transferring to Smith College in Northampton, MA, in 1899. She received an A.B. in English from Smith in 1902 and returned home to teach elementary school. She met Willa Cather in the summer of 1903 at the home of Sarah Harris, publisher of the Lincoln Courier. Moving to New York City soon afterward, Lewis settled into a studio on Washington Square and found work at the Century Publishing Company. Cather was her guest when she visited the city from Pittsburgh. In 1906, at Cather's suggestion, Lewis applied for a position as an editorial proofreader at McClure's Magazine, and the two women worked together on the McClure's staff for six years. In 1908, they moved into a shared apartment at 82 Washington Place, and then, in 1912, to Five Bank Street. Lewis left McClure's in 1915 to become managing editor of Every Week Magazine, where she stayed until the magazine folded in 1918. In 1919 she began a long career as an advertising copywriter at the J. Walter Thompson Co. In 1926 Edith Lewis acquired the land on which she and Cather built their cottage on Grand Manan Island. When they lost their apartment on Bank Street to subway construction in 1927, they shared quarters at the Grosvenor Hotel when they were both in New York City. In 1932 they took an apartment at 570 Park Avenue. Throughout their relationship, Lewis was closely involved in Cather's creative process, reading and editing her work in pre-publication forms. Cather's will appointed Lewis as executor of her literary estate and a beneficiary of her literary trust. Lewis authorized E.K. Brown as Cather's first biographer and published her own memoir of Cather, Willa Cather Living (1953). She remained in their Park Avenue apartment after Cather's death and died there after a long period of illness and invalidism. She is buried at Cather's side in Jaffrey, NH.Ferris, Mollie (c. 1864-1941). Cather family friend in Red Cloud. Ferris was a close friend of Cather’s mother. Willa Cather and Ferris served jointly as godmothers when Cather’s niece Helen Louise Cather was christened in Red Cloud, NE, in 1918. When Ferris died, Cather contributed money for a stained glass window in her honor in Grace Episcopal Church in Red Cloud.Huffman, Elizabeth M. “Lizzie” (1901- ). Worker for the Cather family. Elizabeth and Raymond K. Huffman married in 1921. She worked in the households of the Charles F. Cather and Bernard McNeny families before moving to Stratton, in Hitchcock County, NE, by 1930; her family included a son, Richard, born in 1922, and a daughter, Emma Arlene, born in 1924. By 1940 the family was living in Haxton, CO.",
+          "text" : "⬩W⬩S⬩C⬩ Jaffrey,Nov. 3rdDear Sister; Now you must not write me when you are deadly tired. Send me a single sheet of paper from time to time and say on it \"I am not displeased, but busy.\" I will understand. If you are running a temperature every day, I think you ought to stop teaching and live a quiet life in your own home. (What can you be afraid of there? To me it seems full of peace and protection, as it was those last years for Father and Mother.) At least you ought to see a doctor and try to find out why you have a temperature. I am enclosing a prescription for a nerve tonic, which has seen me through many a tight place. I am never without it. It given me by a very celebrated doctor--he's J.P.Morgan's doctor, and he found that Edith had thyroid when no other doctor co could tell what was wrong with her. Do try this--if you can't take it every three hours, take it before breakfast, before dinner and at bedtime. Three times a day will help, though four four is better. I have sent Molly a check for twenty-five dollars for her Thanksgiving. I had a letter from poor little Lizzie begging to borrow just ten dollars! I was glad to send it; she was so really sweet to Mother always. Now try the tonic and have faith in it. Take it in about a small wine glass full of water. It will help you a lot. With much ever no love, my dear Willie I return to New York in four days from this date."
+        },
+        "highlight" : {
+          "text" : [
+            ". Now try the tonic and have faith in it. Take it in about a small wine glass full of <em>water</em>. It will"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let1971",
+        "_score" : 2.854791,
+        "_source" : {
+          "identifier" : "cat.let1971",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to mary virginia boak cather, [january 27, 1929]",
+          "title" : "Willa Cather to Mary Virginia Boak Cather, [January 27, 1929]",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "January 27, 1929",
+          "date" : "1929-01-27",
+          "date_not_before" : "1929-01-27",
+          "date_not_after" : "1929-01-27",
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "University of Nebraska-Lincoln, Archives and Special Collections, Lincoln, NE",
+          "rights_holder" : "University of Nebraska-Lincoln, Archives and Special Collections, Lincoln, NE",
+          "person" : [
+            {
+              "name" : "Cather, Mary Virginia 'Jennie' Boak",
+              "id" : "0198",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Cather, Mary Virginia 'Jennie' Boak",
+              "id" : "0198"
+            },
+            {
+              "name" : "Lewis, Edith",
+              "id" : "0560"
+            },
+            {
+              "name" : "Hess, Myra",
+              "id" : "0437"
+            },
+            {
+              "name" : "Donovan, Albert",
+              "id" : "0267"
+            },
+            {
+              "name" : "Auld, Jessica Cather",
+              "id" : "0047"
+            },
+            {
+              "name" : "Cather, Elsie",
+              "id" : "0187"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Cather, Mary Virginia 'Jennie' Boak; Cather, Mary Virginia 'Jennie' Boak; Lewis, Edith; Hess, Myra; Donovan, Albert; Auld, Jessica Cather; Cather, Elsie",
+          "keywords" : [ ],
+          "places" : [
+            "New York, New York, United States",
+            "Long Beach, California, United\n                            States"
+          ],
+          "works" : [ ],
+          "annotations" : "Studio portrait of Mary Virginia Boak Cather around the year 1900Philip L. and Helen Cather Southwick Collections, University of Nebraska-Lincoln Libraries Cather, Mary Virginia Boak (1850-1931) (“Virginia” or “Jenny”). Cather’s mother. Born in the Virginia to William Lee Boak and Rachel Seibert Boak, Virginia was educated in Baltimore, MD, and was a schoolteacher until her marriage to Charles Fectigue Cather in 1872. Her husband’s family were primarily Union supporters during the Civil War while her family supported the Confederacy (three brothers served in the Confederate Army although their mother opposed slavery). After her marriage she tried to help unite the divided family. Four of her children, Willa, Roscoe, Charles Douglas, and Jessica Virginia, were born in Virginia, while three, Jessica Virginia, James Donald, Elsie Margaret, and John Esten, were born in Nebraska after the family moved there in 1883. Despite occasional differences, Cather remained in affectionate contact with her mother, who remained in Red Cloud, NE, where the family settled in 1884. After her husband’s death in 1928 Virginia Cather suffered a stroke while visiting her children and their families in California. She spent nearly three years in a sanitarium in Pasadena, CA, unable to speak. Willa Cather visited her there several times but was unable to travel quickly enough from Grand Manan to Red Cloud for her funeral and interment after she died in Pasadena in 1931. Virginia Cather was the prototype for Victoria Templeton in “Old Mrs. Harris” (1932), which Willa Cather completed shortly before her mother’s death.Studio portrait of Mary Virginia Boak Cather around the year 1900Philip L. and Helen Cather Southwick Collections, University of Nebraska-Lincoln Libraries Cather, Mary Virginia Boak (1850-1931) (“Virginia” or “Jenny”). Cather’s mother. Born in the Virginia to William Lee Boak and Rachel Seibert Boak, Virginia was educated in Baltimore, MD, and was a schoolteacher until her marriage to Charles Fectigue Cather in 1872. Her husband’s family were primarily Union supporters during the Civil War while her family supported the Confederacy (three brothers served in the Confederate Army although their mother opposed slavery). After her marriage she tried to help unite the divided family. Four of her children, Willa, Roscoe, Charles Douglas, and Jessica Virginia, were born in Virginia, while three, Jessica Virginia, James Donald, Elsie Margaret, and John Esten, were born in Nebraska after the family moved there in 1883. Despite occasional differences, Cather remained in affectionate contact with her mother, who remained in Red Cloud, NE, where the family settled in 1884. After her husband’s death in 1928 Virginia Cather suffered a stroke while visiting her children and their families in California. She spent nearly three years in a sanitarium in Pasadena, CA, unable to speak. Willa Cather visited her there several times but was unable to travel quickly enough from Grand Manan to Red Cloud for her funeral and interment after she died in Pasadena in 1931. Virginia Cather was the prototype for Victoria Templeton in “Old Mrs. Harris” (1932), which Willa Cather completed shortly before her mother’s death.Studio portrait of Mary Virginia Boak Cather around the year 1900Philip L. and Helen Cather Southwick Collections, University of Nebraska-Lincoln Libraries Cather, Mary Virginia Boak (1850-1931) (“Virginia” or “Jenny”). Cather’s mother. Born in the Virginia to William Lee Boak and Rachel Seibert Boak, Virginia was educated in Baltimore, MD, and was a schoolteacher until her marriage to Charles Fectigue Cather in 1872. Her husband’s family were primarily Union supporters during the Civil War while her family supported the Confederacy (three brothers served in the Confederate Army although their mother opposed slavery). After her marriage she tried to help unite the divided family. Four of her children, Willa, Roscoe, Charles Douglas, and Jessica Virginia, were born in Virginia, while three, Jessica Virginia, James Donald, Elsie Margaret, and John Esten, were born in Nebraska after the family moved there in 1883. Despite occasional differences, Cather remained in affectionate contact with her mother, who remained in Red Cloud, NE, where the family settled in 1884. After her husband’s death in 1928 Virginia Cather suffered a stroke while visiting her children and their families in California. She spent nearly three years in a sanitarium in Pasadena, CA, unable to speak. Willa Cather visited her there several times but was unable to travel quickly enough from Grand Manan to Red Cloud for her funeral and interment after she died in Pasadena in 1931. Virginia Cather was the prototype for Victoria Templeton in “Old Mrs. Harris” (1932), which Willa Cather completed shortly before her mother’s death.Edith Lewis in the 1920sCharles E. Cather Collection, University of Nebraska-Lincoln Libraries Lewis, Edith Labaree (1881-1972). Magazine editor, advertising copywriter, and Cather's domestic partner. Born in Lincoln, NE, to Henry Euclid Lewis and Lillie Gould Lewis, Edith Lewis attended the preparatory school associated with the University of Nebraska, earning college credits from the University before transferring to Smith College in Northampton, MA, in 1899. She received an A.B. in English from Smith in 1902 and returned home to teach elementary school. She met Willa Cather in the summer of 1903 at the home of Sarah Harris, publisher of the Lincoln Courier. Moving to New York City soon afterward, Lewis settled into a studio on Washington Square and found work at the Century Publishing Company. Cather was her guest when she visited the city from Pittsburgh. In 1906, at Cather's suggestion, Lewis applied for a position as an editorial proofreader at McClure's Magazine, and the two women worked together on the McClure's staff for six years. In 1908, they moved into a shared apartment at 82 Washington Place, and then, in 1912, to Five Bank Street. Lewis left McClure's in 1915 to become managing editor of Every Week Magazine, where she stayed until the magazine folded in 1918. In 1919 she began a long career as an advertising copywriter at the J. Walter Thompson Co. In 1926 Edith Lewis acquired the land on which she and Cather built their cottage on Grand Manan Island. When they lost their apartment on Bank Street to subway construction in 1927, they shared quarters at the Grosvenor Hotel when they were both in New York City. In 1932 they took an apartment at 570 Park Avenue. Throughout their relationship, Lewis was closely involved in Cather's creative process, reading and editing her work in pre-publication forms. Cather's will appointed Lewis as executor of her literary estate and a beneficiary of her literary trust. Lewis authorized E.K. Brown as Cather's first biographer and published her own memoir of Cather, Willa Cather Living (1953). She remained in their Park Avenue apartment after Cather's death and died there after a long period of illness and invalidism. She is buried at Cather's side in Jaffrey, NH.No annotation is availableNo annotation is availableAuld, Jessica Virginia Cather (1881-1964) (“Jessie”). Cather’s sister. Born in Virginia and raised in Red Cloud, NE, Jessica was the fourth child and second daughter of Charles and Virginia Cather. After graduating from Red Cloud High School in 1899, she taught at a country school and the South Side Grade School until her marriage to James William Auld, a Red Cloud banker, in 1904. They had three children (Charles, William Thomas, and Mary Virginia). After their divorce in 1933, she moved to Palo Alto, CA, where she died thirty-one years later. Few letters from Willa Cather to her sister Jessica survive, and particularly after Jessica’s divorce their relationship was strained.A studio portrait of Elsie Margaret Cather Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Cather, Elsie Margaret (1890-1964) (“Bobbie”). Cather’s sister. Born in Red Cloud, NE, shortly before Willa Cather graduated from high school, Elsie attended the University of Nebraska in Lincoln from 1908 to 1910, before transferring to Smith College, in Northampton, MA, from which she graduated with an A.B. in English and Latin in 1912. She undertook graduate study at the University of Nebraska in 1914 and in 1916 received her A.M. with a major in philosophy and a minor in English. At both the undergraduate and the graduate level at Nebraska, she studied under Louise Pound. She began a career in high school teaching in 1912, when she took a position in Lander, WY, where her brother Roscoe then lived with his family. She also taught in Albuquerque, NM; Corning, IA; Cleveland, OH; and briefly Red Cloud, when illness in the family brought her home. Her longest tenure as a teacher was at Lincoln (NE) High School, where she began teaching in 1920, with Olivia Pound and Mariel Gere as colleagues. Willa Cather's expectation that Elsie be responsible for aging family and friends and for legal affairs after their parents' deaths sometimes brought the sisters into conflict. Elsie Cather retired from Lincoln High School in 1942. She died in Lincoln.",
+          "text" : "Stroke—1928 1930? Mrs. C. F. Cather 130 Linden avenue Long Beach California NEW YORK, N. Y. GRAND CENTRAL STA. JAN 27 191929 330PM The Grosvenor35 FIFTH AVENUENew York VIRTUS NON STEMMAThe Grosvenor35 FIFTH AVENUENew York Monday My Darling Mother I cannot use the typewriter because Edith is asleep. I have been without any voice for several days—not the usual kind of cold. I don't cough, I am simply as hoarse as a crow and it hurts my throat to talk, so I don't talk. I expect you are talking more than I am just now. I seem 2to remember that you used to get just this kind of throat and lose your voice. Almost every one I know has inf influenza, but I have not. I am working very hard and see few people. I went out to tea with Myra Hess, at her rooms. As I could not talk any, she played the piano—which was better. Last night the faithful Donovan came for dinner—the first time I have seen him since Christmas. Sister Jessie, by the way, wrote me a lecture on diet by way of a Christmas greeting, and said at last you had a Doctor who would keep you on barley water for the rest of your life. I did not reply to this sermon. Silence is surely better. When I go out to see you I will stay at a hotel near you—I don't want to add to the housekeeping, and I can be with you just as much as if I were in the same house, and in that way I won't make any more work for Elsie. I can stay with you when Elsie and your nurse go out. I'm so glad you have a nice nurse and a nice doctor; that means a great deal when one is sick. Goodnight now, dear mother, I hope this will be a good night for you, with refreshing sleep and happy dreams. Very lovingly Willa"
+        },
+        "highlight" : {
+          "text" : [
+            " greeting, and said at last you had a Doctor who would keep you on barley <em>water</em> for the rest of your life"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let2343",
+        "_score" : 2.754172,
+        "_source" : {
+          "identifier" : "cat.let2343",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to elizabeth cather and margaret cather [summer 1936]",
+          "title" : "Willa Cather to Elizabeth Cather and Margaret Cather [Summer 1936]",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "N.D.",
+          "date" : null,
+          "date_not_before" : null,
+          "date_not_after" : null,
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "University of Nebraska–Lincoln, Archives and Special Collections",
+          "rights_holder" : "University of Nebraska–Lincoln, Archives and Special Collections",
+          "person" : [
+            {
+              "name" : "Shannon, Margaret Cather",
+              "id" : "0197",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Shannon, Margaret Cather",
+              "id" : "0197"
+            },
+            {
+              "name" : "Mellen, Mary Virginia Auld",
+              "id" : "0044"
+            },
+            {
+              "name" : "Cather, Elsie",
+              "id" : "0187"
+            },
+            {
+              "name" : "Brockway, Virginia Cather",
+              "id" : "0201"
+            },
+            {
+              "name" : "Lewis, Edith",
+              "id" : "0560"
+            },
+            {
+              "name" : "Jordan, Mary Adela",
+              "id" : "0494"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Shannon, Margaret Cather; Shannon, Margaret Cather; Mellen, Mary Virginia Auld; Cather, Elsie; Brockway, Virginia Cather; Lewis, Edith; Jordan, Mary Adela",
+          "keywords" : [ ],
+          "places" : [
+            "Grand Manan, New Brunswick, Canada",
+            "Casper, Wyoming, United States",
+            "New Brunswick, Canada"
+          ],
+          "works" : [ ],
+          "annotations" : "Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Mary Virginia on a visit to Cather and Lewis's Grand Manan cottege in 1933Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Mellen, Mary Virginia Auld (1906-1982) (“Virginia,” “M.V.”). Cather's niece. Born in Red Cloud, NE, to Jessica Cather Auld and James William Auld, Mary Virginia graduated from Red Cloud High School in 1924 and then spent a year at Dana Hall in Wellesley, MA, to qualify for admission to Smith College in Northampton, MA. In 1929 she received an A.B. in psychology from Smith and then moved to New York City, where she found work at Lord & Taylor before telling her aunt of her arrival. In 1930, probably with Willa Cather's help, she secured a position in the Circulation Department of the New York Public Library. In 1931, she entered the library's internal training school and in 1932 was assigned to the Tremont branch library in the Bronx. After Mary Virginia’s parents divorced in 1933 Cather took a quasi-parental role. She paid for vacations and when, in 1935, Mary Virginia married Richard (Dick) Mellen, a graduate of Harvard Medical School and roommate of her brother William Thomas Auld at Amherst College, she supervised wedding arrangements. After Dick was commissioned as a doctor in the Air Force, Mary Virginia—much to Cather’s regret—accompanied him to Chattanooga, TN, where he was assigned. In Cather's will, Mary Virginia was designated a beneficiary of the literary estate.A studio portrait of Elsie Margaret Cather Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Cather, Elsie Margaret (1890-1964) (“Bobbie”). Cather’s sister. Born in Red Cloud, NE, shortly before Willa Cather graduated from high school, Elsie attended the University of Nebraska in Lincoln from 1908 to 1910, before transferring to Smith College, in Northampton, MA, from which she graduated with an A.B. in English and Latin in 1912. She undertook graduate study at the University of Nebraska in 1914 and in 1916 received her A.M. with a major in philosophy and a minor in English. At both the undergraduate and the graduate level at Nebraska, she studied under Louise Pound. She began a career in high school teaching in 1912, when she took a position in Lander, WY, where her brother Roscoe then lived with his family. She also taught in Albuquerque, NM; Corning, IA; Cleveland, OH; and briefly Red Cloud, when illness in the family brought her home. Her longest tenure as a teacher was at Lincoln (NE) High School, where she began teaching in 1920, with Olivia Pound and Mariel Gere as colleagues. Willa Cather's expectation that Elsie be responsible for aging family and friends and for legal affairs after their parents' deaths sometimes brought the sisters into conflict. Elsie Cather retired from Lincoln High School in 1942. She died in Lincoln.Brockway, Virginia Cather (1912-1983) (“West Virginia”). Cather's niece. Born in Lander, WY, to Roscoe Cather and Meta Schaper Cather, Virginia graduated from Natrona County High School in Casper, WY, in 1929. She received an A.B. in English from Smith College in Northampton, MA, in 1933, the same year Willa Cather received an honorary doctorate there. In 1934, she enrolled in the University of Chicago School of Social Services and was, for a time, a social worker. She married John Hadley Brockway, a Navy officer, in 1936. They moved frequently until his retirement from the Navy. She had one child, son George. In letters, Willa Cather sometimes calls her \"West Virginia\" to distinguish her from her cousin Mary Virginia Auld because Virginia Cather's birthplace in Wyoming was farther west than Mary Virginia's in Nebraska.Edith Lewis in the 1920sCharles E. Cather Collection, University of Nebraska-Lincoln Libraries Lewis, Edith Labaree (1881-1972). Magazine editor, advertising copywriter, and Cather's domestic partner. Born in Lincoln, NE, to Henry Euclid Lewis and Lillie Gould Lewis, Edith Lewis attended the preparatory school associated with the University of Nebraska, earning college credits from the University before transferring to Smith College in Northampton, MA, in 1899. She received an A.B. in English from Smith in 1902 and returned home to teach elementary school. She met Willa Cather in the summer of 1903 at the home of Sarah Harris, publisher of the Lincoln Courier. Moving to New York City soon afterward, Lewis settled into a studio on Washington Square and found work at the Century Publishing Company. Cather was her guest when she visited the city from Pittsburgh. In 1906, at Cather's suggestion, Lewis applied for a position as an editorial proofreader at McClure's Magazine, and the two women worked together on the McClure's staff for six years. In 1908, they moved into a shared apartment at 82 Washington Place, and then, in 1912, to Five Bank Street. Lewis left McClure's in 1915 to become managing editor of Every Week Magazine, where she stayed until the magazine folded in 1918. In 1919 she began a long career as an advertising copywriter at the J. Walter Thompson Co. In 1926 Edith Lewis acquired the land on which she and Cather built their cottage on Grand Manan Island. When they lost their apartment on Bank Street to subway construction in 1927, they shared quarters at the Grosvenor Hotel when they were both in New York City. In 1932 they took an apartment at 570 Park Avenue. Throughout their relationship, Lewis was closely involved in Cather's creative process, reading and editing her work in pre-publication forms. Cather's will appointed Lewis as executor of her literary estate and a beneficiary of her literary trust. Lewis authorized E.K. Brown as Cather's first biographer and published her own memoir of Cather, Willa Cather Living (1953). She remained in their Park Avenue apartment after Cather's death and died there after a long period of illness and invalidism. She is buried at Cather's side in Jaffrey, NH.No annotation is available",
+          "text" : "The Misses Cather 1225 South Center St. Casper Wyoming (U. S. A.) N. B. 1936 Darling Twinnies; Here is a nice letter from Mary Virginia which you must read and need not return. I held it until after Elsie's visit with you—she is inclined to be jealous of anything I do for M.V. I toldwrote Virginia you had promised not to announce your Virginia's wedding until she herself did, and you weren't \"holding out\" on her. (What a sentence! Which pronoun belongs to which Virginia!) Now, please, you must write to Edith and to me. You will find that the result of being popular and loved is that you have to spend most of your life writing letters! We had our Sunday dinner in our snug little home last night. Menu Chicken Soup (with rice) Fried Chicken Green Beans Polenta (Italian baked mush with Swiss Cheese) Tomato Salad (Miss Jordan's fresh lettuce with ripe tomatoes, parsley and a little garlic) Gooseberries Anglaise (Cooked with ⅓½ sugar but no water for just eight minutes, cooled and served with sour cream) Edith did the chicken and polenta, I did the beans and salad and the gooseberry dessert. We had Pommard,—the red Burgundy we had for you. Love from W. S. C."
+        },
+        "highlight" : {
+          "text" : [
+            ") Gooseberries Anglaise (Cooked with ⅓½ sugar but no <em>water</em> for just eight minutes, cooled and served"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let2370",
+        "_score" : 2.754172,
+        "_source" : {
+          "identifier" : "cat.let2370",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to margaret cather shannon, february 6, 1941",
+          "title" : "Willa Cather to Margaret Cather Shannon, February 6, 1941",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "February 6, 1941",
+          "date" : "1941-02-06",
+          "date_not_before" : "1941-02-06",
+          "date_not_after" : "1941-02-06",
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "University of Nebraska–Lincoln, Archives and Special Collections",
+          "rights_holder" : "University of Nebraska–Lincoln, Archives and Special Collections",
+          "person" : [
+            {
+              "name" : "Shannon, Margaret Cather",
+              "id" : "0197",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Shannon, Margaret Cather",
+              "id" : "0197"
+            },
+            {
+              "name" : "Cather, Roscoe",
+              "id" : "0200"
+            },
+            {
+              "name" : "Cather, Meta Schaper",
+              "id" : "0199"
+            },
+            {
+              "name" : "Ickis, Elizabeth Cather",
+              "id" : "0185"
+            },
+            {
+              "name" : "",
+              "id" : "psn"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Shannon, Margaret Cather; Shannon, Margaret Cather; Cather, Roscoe; Cather, Meta Schaper; Ickis, Elizabeth Cather; ",
+          "keywords" : [ ],
+          "places" : [
+            "New York, New York, United States",
+            "New Mexico, United States",
+            "Grand Manan, New Brunswick, Canada"
+          ],
+          "works" : [ ],
+          "annotations" : "Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Shannon, Margaret Cather (1915-1996) (half of the “twinnies”). Cather’s niece. Margaret and her twin sister Elizabeth were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them, she often refers back to their summer visits as a magical time. Margaret moved to Colusa, CA, with her parents in 1937. After she married Richard Shannon in September 1938, she moved with him to Boston, MA, where he earned an MBA from Harvard University in Cambridge. In 1940 they moved to the New York City area, where their first child, Richard, was born in 1943. The Shannons moved to Washington, DC, in 1944, where their daughter Kathryne was born. Cather did not see Margaret again after she left New York, and Margaret’s other three children, Patricia, Margaret, and Elizabeth, were born after Cather’s death. Kathryne and Patricia became caretakers for a large family archive of letters preserved by their mother, which they donated to the University of Nebraska-Lincoln as the Roscoe and Meta Cather Collection.Roscoe CatherRoscoe and Meta Cather Collection, University of Nebraska-Lincoln Libraries Cather, Roscoe (1877-1945) (“Ross”). Cather’s brother. Roscoe was born in Virginia, the second child and oldest son of Charles and Virginia Cather. After graduating from Red Cloud (NE) High School in 1895, he taught country school for two years, attended the University of Nebraska in Lincoln for one year (1897-1898), taught high school in Carlton, NE, and Oxford, NE, and finally became superintendent of schools in Fullerton, NE. There he met fellow teacher Meta Schaper, whom he married in 1907. They relocated to Lander, WY, in 1909, where he opened an abstract office and where their three children, Virginia and twins Margaret and Elizabeth, were born. In 1921, they moved to Casper, WY, where Roscoe became president of the Wyoming Trust Company, and in 1937 to Colusa, CA, where Roscoe and his brother Douglass had acquired a controlling interest in the First Savings Bank of Colusa. Roscoe served as president of the bank until his death. Willa visited Roscoe and his family in Wyoming several times and shared important travel experiences with them, including a 1926 trip to New Mexico with Roscoe, Meta, and their children and a 1941 San Francisco vacation with Roscoe and Meta. She also relied on him to handle family-related business as well as personal financial matters, and he was one of her chief correspondents throughout her life. Roscoe served as a prototype for one of the twin brothers in the Templeton family in “Old Mrs. Harris” (1932).Studio portrait of Meta Schaper Cather around the year 1900Roscoe and Meta Cather Collection, University of Nebraska-Lincoln Libraries Cather, Meta Schaper (1884-1973). Cather’s sister-in-law. Meta Schaper was born in Plattsmouth, NE, the second daughter of Robert and Julia Ramke Schaper. After graduating from the University of Nebraska in Lincoln 1903, Meta Schaper taught at Havelock High School in her hometown of Havelock, NE (now part of Lincoln). She met Roscoe Cather when teaching in Fullerton, NE, and they married in 1907. They moved to Lander, WY, in 1909, where she gave birth to three daughters, Virginia and twins Margaret and Elizabeth. The family moved to Casper, WY, in 1921 and Colusa, CA, in 1937. Willa visited Meta and Roscoe’s family in Wyoming several times and shared important travel experiences with them, including a 1926 trip to New Mexico with Meta, Roscoe, and their children and a 1941 San Francisco vacation with Roscoe and Meta. Meta and Willa remained friends until Willa’s death.Ickis, Elizabeth Cather (1915-1978) (half of the “twinnies”). Cather’s niece. Elizabeth and her twin sister Margaret were born in Lander, WY, to Roscoe and Meta Cather, and moved with the family to Casper, WY, in 1921. Elizabeth and Margaret both attended the University of Colorado, graduating in 1937, and visited Willa Cather and Edith Lewis on Grand Manan during the summers of 1936 and 1937. In Cather’s later letters to them she often refers back to their summer visits as a magical time. Elizabeth moved to Colusa, CA, with her parents in 1937 and married Lynn S. Ickis, an electrical engineer, in April 1938. They lived in Detroit, MI, where their daughter Margaret was born in 1939, and Cleveland, OH, where son John was born in 1943.",
+          "text" : "Mrs. R. S. Shannon, Jr., 1988 – 78th Street, Jackson Heights, New York. NEW YORK, N.Y. FEB 6 1941 8–PM ⬩W⬩S⬩C⬩ February 6, 1941. My darling Margaret: None of my Christmas cards (and there were a great many) pleased me as much as your dear little donkey. He is certainly an Italian donkey, but all the same he reminded me of New Mexico and our pleasant visit there together, along with your father and mother and Elizabeth. I have not written you, my dear, because I cannot write at all. I have scarcely time to get bored, because after I have given my hand hot water treatment for half an hour, morning and afternoon, and had a splendid masseuse from Dick's hospital work on it every other day and then give it the proper amount of treatment under the lamp, there isn't very much of the day left. Please remember that I think of you and Elizabeth very often when I am resting after these rather exhausting treatments, and it is pleasant to let my mind loaf along and bring back the bright days we spent at Grand Manan. More personal communication is difficult when I cannot write (not even a line) and you cannot telephone. But some day I will telegraph you and try to make a date. A Happy New Year to you, my dear. With much love, Your Aunt Willie Per Sarah J. BloomSecretary"
+        },
+        "highlight" : {
+          "text" : [
+            " scarcely time to get bored, because after I have given my hand hot <em>water</em> treatment for half an hour"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let1974",
+        "_score" : 2.4281716,
+        "_source" : {
+          "identifier" : "cat.let1974",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to elsie cather, [june 9, 1935]",
+          "title" : "Willa Cather to Elsie Cather, [June 9, 1935]",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "June 9, 1935",
+          "date" : "1935-06-09",
+          "date_not_before" : "1935-06-09",
+          "date_not_after" : "1935-06-09",
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "University of Nebraska-Lincoln, Archives and Special Collections, Lincoln, NE",
+          "rights_holder" : "University of Nebraska-Lincoln, Archives and Special Collections, Lincoln, NE",
+          "person" : [
+            {
+              "name" : "Cather, Elsie",
+              "id" : "0187",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Cather, Elsie",
+              "id" : "0187"
+            },
+            {
+              "name" : "Creighton, Mary Miner",
+              "id" : "0242"
+            },
+            {
+              "name" : "Cather, Roscoe",
+              "id" : "0200"
+            },
+            {
+              "name" : "Auld, William Thomas 'Tom, Will'",
+              "id" : "0049"
+            },
+            {
+              "name" : "Bourda, Joséphine Marie Bernardine Brun",
+              "id" : "0112"
+            },
+            {
+              "name" : "Lewis, Edith",
+              "id" : "0560"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Cather, Elsie; Cather, Elsie; Creighton, Mary Miner; Cather, Roscoe; Auld, William Thomas 'Tom, Will'; Bourda, Joséphine Marie Bernardine Brun; Lewis, Edith",
+          "keywords" : [ ],
+          "places" : [
+            "New York, New York, United States",
+            "Lincoln, Nebraska, United States",
+            "Red Cloud, Nebraska, United States"
+          ],
+          "works" : [ ],
+          "annotations" : "A studio portrait of Elsie Margaret Cather Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Cather, Elsie Margaret (1890-1964) (“Bobbie”). Cather’s sister. Born in Red Cloud, NE, shortly before Willa Cather graduated from high school, Elsie attended the University of Nebraska in Lincoln from 1908 to 1910, before transferring to Smith College, in Northampton, MA, from which she graduated with an A.B. in English and Latin in 1912. She undertook graduate study at the University of Nebraska in 1914 and in 1916 received her A.M. with a major in philosophy and a minor in English. At both the undergraduate and the graduate level at Nebraska, she studied under Louise Pound. She began a career in high school teaching in 1912, when she took a position in Lander, WY, where her brother Roscoe then lived with his family. She also taught in Albuquerque, NM; Corning, IA; Cleveland, OH; and briefly Red Cloud, when illness in the family brought her home. Her longest tenure as a teacher was at Lincoln (NE) High School, where she began teaching in 1920, with Olivia Pound and Mariel Gere as colleagues. Willa Cather's expectation that Elsie be responsible for aging family and friends and for legal affairs after their parents' deaths sometimes brought the sisters into conflict. Elsie Cather retired from Lincoln High School in 1942. She died in Lincoln.A studio portrait of Elsie Margaret Cather Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Cather, Elsie Margaret (1890-1964) (“Bobbie”). Cather’s sister. Born in Red Cloud, NE, shortly before Willa Cather graduated from high school, Elsie attended the University of Nebraska in Lincoln from 1908 to 1910, before transferring to Smith College, in Northampton, MA, from which she graduated with an A.B. in English and Latin in 1912. She undertook graduate study at the University of Nebraska in 1914 and in 1916 received her A.M. with a major in philosophy and a minor in English. At both the undergraduate and the graduate level at Nebraska, she studied under Louise Pound. She began a career in high school teaching in 1912, when she took a position in Lander, WY, where her brother Roscoe then lived with his family. She also taught in Albuquerque, NM; Corning, IA; Cleveland, OH; and briefly Red Cloud, when illness in the family brought her home. Her longest tenure as a teacher was at Lincoln (NE) High School, where she began teaching in 1920, with Olivia Pound and Mariel Gere as colleagues. Willa Cather's expectation that Elsie be responsible for aging family and friends and for legal affairs after their parents' deaths sometimes brought the sisters into conflict. Elsie Cather retired from Lincoln High School in 1942. She died in Lincoln.A studio portrait of Elsie Margaret Cather Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Cather, Elsie Margaret (1890-1964) (“Bobbie”). Cather’s sister. Born in Red Cloud, NE, shortly before Willa Cather graduated from high school, Elsie attended the University of Nebraska in Lincoln from 1908 to 1910, before transferring to Smith College, in Northampton, MA, from which she graduated with an A.B. in English and Latin in 1912. She undertook graduate study at the University of Nebraska in 1914 and in 1916 received her A.M. with a major in philosophy and a minor in English. At both the undergraduate and the graduate level at Nebraska, she studied under Louise Pound. She began a career in high school teaching in 1912, when she took a position in Lander, WY, where her brother Roscoe then lived with his family. She also taught in Albuquerque, NM; Corning, IA; Cleveland, OH; and briefly Red Cloud, when illness in the family brought her home. Her longest tenure as a teacher was at Lincoln (NE) High School, where she began teaching in 1920, with Olivia Pound and Mariel Gere as colleagues. Willa Cather's expectation that Elsie be responsible for aging family and friends and for legal affairs after their parents' deaths sometimes brought the sisters into conflict. Elsie Cather retired from Lincoln High School in 1942. She died in Lincoln.Creighton, Mary S. Miner (1873-1968). Clubwoman; Cather’s friend from childhood. Born in Iowa, Mary Miner was the second daughter of James and Julia Miner, neighbors of the Cather family in Red Cloud, NE. Willa Cather later recalled that when she first moved into town with her family and enrolled in school in 1885, “Margie Miner was so jolly I wanted awfully to know her.” They became lifelong friends and correspondents, and Mary’s sisters Irene and Carrie were equally close to Cather. Mary Miner wed local physician E. A. Creighton in 1900 and lived the rest of her life in Red Cloud. She was the prototype for Julia Harling in My Ántonia (1918).Roscoe CatherRoscoe and Meta Cather Collection, University of Nebraska-Lincoln Libraries Cather, Roscoe (1877-1945) (“Ross”). Cather’s brother. Roscoe was born in Virginia, the second child and oldest son of Charles and Virginia Cather. After graduating from Red Cloud (NE) High School in 1895, he taught country school for two years, attended the University of Nebraska in Lincoln for one year (1897-1898), taught high school in Carlton, NE, and Oxford, NE, and finally became superintendent of schools in Fullerton, NE. There he met fellow teacher Meta Schaper, whom he married in 1907. They relocated to Lander, WY, in 1909, where he opened an abstract office and where their three children, Virginia and twins Margaret and Elizabeth, were born. In 1921, they moved to Casper, WY, where Roscoe became president of the Wyoming Trust Company, and in 1937 to Colusa, CA, where Roscoe and his brother Douglass had acquired a controlling interest in the First Savings Bank of Colusa. Roscoe served as president of the bank until his death. Willa visited Roscoe and his family in Wyoming several times and shared important travel experiences with them, including a 1926 trip to New Mexico with Roscoe, Meta, and their children and a 1941 San Francisco vacation with Roscoe and Meta. She also relied on him to handle family-related business as well as personal financial matters, and he was one of her chief correspondents throughout her life. Roscoe served as a prototype for one of the twin brothers in the Templeton family in “Old Mrs. Harris” (1932).No annotation is availableBourda, Joséphine Marie Bernardine Brun (1892-1959). Cather’s maid. Raised in Lourdes in the Pyrénées region of France, Joséphine’s father Jean-Marie Brun ran a restaurant. In 1909 she married Alphonse Bourda, and they had two children, Marie, born 1910, and Clémentine, born 1912. In 1913 Joséphine, Alphonse, and Joséphine’s father immigrated to the United States, leaving Marie and Clémentine behind with relatives. Alphonse and Joséphine’s third child, Jeanette, was born in New York City in late 1913. Soon after, Joséphine found work cooking and keeping house for Willa Cather and Edith Lewis in their Five Bank Street apartment. In 1919 the Bourda family was reunited in New York and Joséphine stopped working, but by late 1921, she was back working half days until 1925. She resumed working for Cather and Lewis in 1932 when they moved to a new apartment at 570 Park Avenue, but in 1935, she and her husband decided to return to France because of his failing health. Cather considered Joséphine a personal friend and praised her as “an artist in her way” (#0563). Cather and Bourda evidently corresponded after her return to France but their letters have not surfaced. She died in the village of Saint Pé de Bigorre.Edith Lewis in the 1920sCharles E. Cather Collection, University of Nebraska-Lincoln Libraries Lewis, Edith Labaree (1881-1972). Magazine editor, advertising copywriter, and Cather's domestic partner. Born in Lincoln, NE, to Henry Euclid Lewis and Lillie Gould Lewis, Edith Lewis attended the preparatory school associated with the University of Nebraska, earning college credits from the University before transferring to Smith College in Northampton, MA, in 1899. She received an A.B. in English from Smith in 1902 and returned home to teach elementary school. She met Willa Cather in the summer of 1903 at the home of Sarah Harris, publisher of the Lincoln Courier. Moving to New York City soon afterward, Lewis settled into a studio on Washington Square and found work at the Century Publishing Company. Cather was her guest when she visited the city from Pittsburgh. In 1906, at Cather's suggestion, Lewis applied for a position as an editorial proofreader at McClure's Magazine, and the two women worked together on the McClure's staff for six years. In 1908, they moved into a shared apartment at 82 Washington Place, and then, in 1912, to Five Bank Street. Lewis left McClure's in 1915 to become managing editor of Every Week Magazine, where she stayed until the magazine folded in 1918. In 1919 she began a long career as an advertising copywriter at the J. Walter Thompson Co. In 1926 Edith Lewis acquired the land on which she and Cather built their cottage on Grand Manan Island. When they lost their apartment on Bank Street to subway construction in 1927, they shared quarters at the Grosvenor Hotel when they were both in New York City. In 1932 they took an apartment at 570 Park Avenue. Throughout their relationship, Lewis was closely involved in Cather's creative process, reading and editing her work in pre-publication forms. Cather's will appointed Lewis as executor of her literary estate and a beneficiary of her literary trust. Lewis authorized E.K. Brown as Cather's first biographer and published her own memoir of Cather, Willa Cather Living (1953). She remained in their Park Avenue apartment after Cather's death and died there after a long period of illness and invalidism. She is buried at Cather's side in Jaffrey, NH.",
+          "text" : "Miss Elsie Cather 1030 South 52nd Street Lincoln Nebraska NEW YORK, N. Y. STA Y JUN 15 1935 1130 PM Sunday Dear Sister; No, I did not have a prayer book, and it was good of you to send me this lovely one. This year I was so fretted by my hurt wrist at Easter time that I was especially glad to have any sign that my family remembered me. I would have thanked you long before this, but writing has been impossible for me, as my wright [right] hand got so tired keeping me clean and dressed. My left hand is still in splints. I have electric treatments and massage for it every day. It is not nearly so painful as it was six weeks ago, but everyone seems to agree that a badly sprained tendon takes anywhere from six weeks to three months to recover. Besides massage and dia-thermy I have to keep my hand in hot water for an hour in the morning and half an hour at night, so I really have become a trained nurse with one patient! I am always on the way to a doctor or on the way from one. If anyone in Lincoln should ask about my arm, please say it is doing very well—I don't like sympathy except from real friends, you know. I've written to Mary Creighton just how my arm really is, so the house people know. Roscoe has been to Red Cloud for me to save what he can out of the wreck. I'll send you his letter someday, and a copy of his report on the investments Will Auld made for me; about half of them seem to be all right, the others pretty worthless. Someday I will be able to write you a real letter again. Josephine and Edith are very patient with my infirmities. Edith has to do up my hair, and Josephine puts on my corsets for me! Love to you, and many thanks for my Easter present, dear sister. Willie"
+        },
+        "highlight" : {
+          "text" : [
+            " hand in hot <em>water</em> for an hour in the morning and half an hour at night, so I really have become a"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let2417",
+        "_score" : 2.4281716,
+        "_source" : {
+          "identifier" : "cat.let2417",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to mary virginia boak cather and elsie cather, may 27 [1920]",
+          "title" : "Willa Cather to Mary Virginia Boak Cather and Elsie Cather, May 27 [1920]",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "May 27, 1920",
+          "date" : "1920-05-27",
+          "date_not_before" : "1920-05-27",
+          "date_not_after" : "1920-05-27",
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "University of Nebraska–Lincoln",
+          "rights_holder" : "University of Nebraska–Lincoln",
+          "person" : [
+            {
+              "name" : "Cather, Elsie",
+              "id" : "0187",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Cather, Mary Virginia 'Jennie' Boak",
+              "id" : "0198"
+            },
+            {
+              "name" : "Cather, Elsie",
+              "id" : "0187"
+            },
+            {
+              "name" : "Lewis, Edith",
+              "id" : "0560"
+            },
+            {
+              "name" : "Fremstad, Olive",
+              "id" : "0337"
+            },
+            {
+              "name" : "Pfeiffer, Miss",
+              "id" : "1140"
+            },
+            {
+              "name" : "Mencken, H. L.",
+              "id" : "0646"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Cather, Elsie; Cather, Mary Virginia 'Jennie' Boak; Cather, Elsie; Lewis, Edith; Fremstad, Olive; Pfeiffer, Miss; Mencken, H. L.",
+          "keywords" : [ ],
+          "places" : [
+            "",
+            "New York, New York, United States",
+            "Lincoln, Nebraska, United States",
+            "France"
+          ],
+          "works" : [ ],
+          "annotations" : "A studio portrait of Elsie Margaret Cather Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Cather, Elsie Margaret (1890-1964) (“Bobbie”). Cather’s sister. Born in Red Cloud, NE, shortly before Willa Cather graduated from high school, Elsie attended the University of Nebraska in Lincoln from 1908 to 1910, before transferring to Smith College, in Northampton, MA, from which she graduated with an A.B. in English and Latin in 1912. She undertook graduate study at the University of Nebraska in 1914 and in 1916 received her A.M. with a major in philosophy and a minor in English. At both the undergraduate and the graduate level at Nebraska, she studied under Louise Pound. She began a career in high school teaching in 1912, when she took a position in Lander, WY, where her brother Roscoe then lived with his family. She also taught in Albuquerque, NM; Corning, IA; Cleveland, OH; and briefly Red Cloud, when illness in the family brought her home. Her longest tenure as a teacher was at Lincoln (NE) High School, where she began teaching in 1920, with Olivia Pound and Mariel Gere as colleagues. Willa Cather's expectation that Elsie be responsible for aging family and friends and for legal affairs after their parents' deaths sometimes brought the sisters into conflict. Elsie Cather retired from Lincoln High School in 1942. She died in Lincoln.Studio portrait of Mary Virginia Boak Cather around the year 1900Philip L. and Helen Cather Southwick Collections, University of Nebraska-Lincoln Libraries Cather, Mary Virginia Boak (1850-1931) (“Virginia” or “Jenny”). Cather’s mother. Born in the Virginia to William Lee Boak and Rachel Seibert Boak, Virginia was educated in Baltimore, MD, and was a schoolteacher until her marriage to Charles Fectigue Cather in 1872. Her husband’s family were primarily Union supporters during the Civil War while her family supported the Confederacy (three brothers served in the Confederate Army although their mother opposed slavery). After her marriage she tried to help unite the divided family. Four of her children, Willa, Roscoe, Charles Douglas, and Jessica Virginia, were born in Virginia, while three, Jessica Virginia, James Donald, Elsie Margaret, and John Esten, were born in Nebraska after the family moved there in 1883. Despite occasional differences, Cather remained in affectionate contact with her mother, who remained in Red Cloud, NE, where the family settled in 1884. After her husband’s death in 1928 Virginia Cather suffered a stroke while visiting her children and their families in California. She spent nearly three years in a sanitarium in Pasadena, CA, unable to speak. Willa Cather visited her there several times but was unable to travel quickly enough from Grand Manan to Red Cloud for her funeral and interment after she died in Pasadena in 1931. Virginia Cather was the prototype for Victoria Templeton in “Old Mrs. Harris” (1932), which Willa Cather completed shortly before her mother’s death.A studio portrait of Elsie Margaret Cather Philip L. and Helen Cather Southwick Collection, University of Nebraska-Lincoln Libraries Cather, Elsie Margaret (1890-1964) (“Bobbie”). Cather’s sister. Born in Red Cloud, NE, shortly before Willa Cather graduated from high school, Elsie attended the University of Nebraska in Lincoln from 1908 to 1910, before transferring to Smith College, in Northampton, MA, from which she graduated with an A.B. in English and Latin in 1912. She undertook graduate study at the University of Nebraska in 1914 and in 1916 received her A.M. with a major in philosophy and a minor in English. At both the undergraduate and the graduate level at Nebraska, she studied under Louise Pound. She began a career in high school teaching in 1912, when she took a position in Lander, WY, where her brother Roscoe then lived with his family. She also taught in Albuquerque, NM; Corning, IA; Cleveland, OH; and briefly Red Cloud, when illness in the family brought her home. Her longest tenure as a teacher was at Lincoln (NE) High School, where she began teaching in 1920, with Olivia Pound and Mariel Gere as colleagues. Willa Cather's expectation that Elsie be responsible for aging family and friends and for legal affairs after their parents' deaths sometimes brought the sisters into conflict. Elsie Cather retired from Lincoln High School in 1942. She died in Lincoln.Edith Lewis in the 1920sCharles E. Cather Collection, University of Nebraska-Lincoln Libraries Lewis, Edith Labaree (1881-1972). Magazine editor, advertising copywriter, and Cather's domestic partner. Born in Lincoln, NE, to Henry Euclid Lewis and Lillie Gould Lewis, Edith Lewis attended the preparatory school associated with the University of Nebraska, earning college credits from the University before transferring to Smith College in Northampton, MA, in 1899. She received an A.B. in English from Smith in 1902 and returned home to teach elementary school. She met Willa Cather in the summer of 1903 at the home of Sarah Harris, publisher of the Lincoln Courier. Moving to New York City soon afterward, Lewis settled into a studio on Washington Square and found work at the Century Publishing Company. Cather was her guest when she visited the city from Pittsburgh. In 1906, at Cather's suggestion, Lewis applied for a position as an editorial proofreader at McClure's Magazine, and the two women worked together on the McClure's staff for six years. In 1908, they moved into a shared apartment at 82 Washington Place, and then, in 1912, to Five Bank Street. Lewis left McClure's in 1915 to become managing editor of Every Week Magazine, where she stayed until the magazine folded in 1918. In 1919 she began a long career as an advertising copywriter at the J. Walter Thompson Co. In 1926 Edith Lewis acquired the land on which she and Cather built their cottage on Grand Manan Island. When they lost their apartment on Bank Street to subway construction in 1927, they shared quarters at the Grosvenor Hotel when they were both in New York City. In 1932 they took an apartment at 570 Park Avenue. Throughout their relationship, Lewis was closely involved in Cather's creative process, reading and editing her work in pre-publication forms. Cather's will appointed Lewis as executor of her literary estate and a beneficiary of her literary trust. Lewis authorized E.K. Brown as Cather's first biographer and published her own memoir of Cather, Willa Cather Living (1953). She remained in their Park Avenue apartment after Cather's death and died there after a long period of illness and invalidism. She is buried at Cather's side in Jaffrey, NH.Fremstad, Olive (1871-1951). Swedish-American opera singer. Born in Sweden, Ann Olivia Rundquist was adopted by a Scandinavian-American couple, the Fremstads, who raised her first in Kristiania (now Oslo), Norway, and then in Minnesota. She moved to New York City to study piano in 1890 and then to Germany to study voice with Lilli Lehmann. After a successful career in Europe as a mezzo-soprano, she made her debut at the Metropolitan Opera in 1903, where she specialized in singing soprano roles in operas by Richard Wagner. Willa Cather first met Fremstad in 1913 while researching “Three American Singers,” an article for McClure’s Magazine in which Cather clearly prefers Fremstad as “the most interesting kind of American” over Geraldine Farrar and Louise Homer. Through 1916 Cather and Fremstad were in close and regular contact in person and through letters, although Cather’s letters to Fremstad have not been located and their friendship evidently cooled. Fremstad inspired many aspects of the story, personality, and career of Thea Kronborg, heroine of The Song of the Lark (1915), and she approved of the novel, although Cather did not want readers to identify the character too closely with her. Fremstad married and divorced twice. During the period Cather and Fremstad were in regular contact Fremstad lived as a couple with Mary Watkins (later Cushing) who, after Fremstad’s death, published a biography of her, The Rainbow Bridge (1954).No annotation is availableNo annotation is available",
+          "text" : "THE CUNARD STEAM SHIP COMPANY LIMITED R.M.S. \"ROYAL GEORGE.\" May 27 My Dearest Mother and Elsie: A week today since we left land, and we land in three days more. I have never had such a restful, peaceful crossing before. The weather has been beautiful, cold but not too rough, and I have felt exceptionally well all the time. Edith is always seasick and has been miserable—had to stay in her cabin most of the time. I don’t see how she can be so patient. We left New York with our cabin full of fruit and flowers, six baskets of fruit in all and three boxes of flowers,—from both my publishers and from Madame Fremstad and other friends. I sent a lot of it the fruit down to the children in the steerage and gave one basket of it to Miss Pfeiffer, of Lincoln. As Edith can’t eat any fruit, I am not equal 3to it alone. I saved your letter and Elsie’s to open and read on the steamer. Yes, Elsie, the novelette in my room is the one Mencken bought for the “Smart Set.” It had to be cut and changed so for the magazine that I don’t see why they wanted it—I really think they wanted me to have the $450 they paid me for it to help me on my travels. They never pay anybody else more than $100 so they make good their faith with works which is more 4than most admirers do. I liked Miss Pfeiffer when I was a kid, and still like her, but that hard grind has surely worn her out. The Suffragettes don’t bother much—some of them are nice and some dreadful. But there are many nice English and French people on board. I do very little but eat and sleep and look at the sea and look at the water, and sometimes think about the new novel that will be so good or so bad. I’ve not many ideas about it, but I’ve a great deal of love and a good deal of faith. Goodbye now, dearest ones, I will write again from France. Willa"
+        },
+        "highlight" : {
+          "text" : [
+            " on board. I do very little but eat and sleep and look at the sea and look at the <em>water</em>, and"
+          ]
+        }
+      },
+      {
+        "_index" : "test1",
+        "_type" : "cather",
+        "_id" : "cat.let2628",
+        "_score" : 2.4281716,
+        "_source" : {
+          "identifier" : "cat.let2628",
+          "category" : "Writings",
+          "subcategory" : "Letters",
+          "data_type" : "tei",
+          "collection" : "cather_letters",
+          "shortname" : "cather",
+          "title_sort" : "willa cather to alfred knopf, july 31 [1931]",
+          "title" : "Willa Cather to Alfred Knopf, July 31 [1931]",
+          "description" : null,
+          "format" : "letter",
+          "language" : null,
+          "medium" : "letter",
+          "date_display" : "July 31, 1931",
+          "date" : "1931-07-31",
+          "date_not_before" : "1931-07-31",
+          "date_not_after" : "1931-07-31",
+          "rights_uri" : null,
+          "publisher" : "University of Nebraska–Lincoln",
+          "rights" : "All Rights Reserved",
+          "source" : "Barbara Dobkin Collection, New York, NY",
+          "rights_holder" : "Barbara Dobkin Collection, New York, NY",
+          "person" : [
+            {
+              "name" : "Knopf, Alfred A.",
+              "id" : "0518",
+              "role" : "addressee"
+            },
+            {
+              "name" : "Knopf, Alfred A.",
+              "id" : "0518"
+            },
+            {
+              "name" : "Evans, Mr.",
+              "id" : "0298"
+            },
+            {
+              "name" : "Salzberg, Mr.",
+              "id" : "0821"
+            },
+            {
+              "name" : "Knopf, Blanche",
+              "id" : "0520"
+            },
+            {
+              "name" : "",
+              "id" : "psn"
+            }
+          ],
+          "contributor" : [
+            {
+              "name" : "Andrew Jewell",
+              "id" : "awj",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Janis Stout",
+              "id" : "ja_st",
+              "role" : "co-editor"
+            },
+            {
+              "name" : "Melissa Homestead",
+              "id" : "me_ho",
+              "role" : "associate_editor"
+            }
+          ],
+          "creator" : [
+            {
+              "name" : "Willa Cather"
+            }
+          ],
+          "creator_sort" : "Willa Cather",
+          "people" : "Knopf, Alfred A.; Knopf, Alfred A.; Evans, Mr.; Salzberg, Mr.; Knopf, Blanche; ",
+          "keywords" : [ ],
+          "places" : [
+            "Grand Manan, New Brunswick, Canada",
+            "Canada",
+            "St. John, New Brunswick, Canada",
+            "Paris, Île-de-France, France",
+            "Aix-les-Bains, Rhône-Alpes, France"
+          ],
+          "works" : [ ],
+          "annotations" : "A portrait of Alfred A. Knopf taken by Carl Van Vechten on March 31, 1935The United States Library of Congress Knopf, Alfred A. (1892-1984). President of New York publisher Alfred A. Knopf, Inc. Knopf received his B.A. from Columbia University in New York City in 1912 and founded Alfred Knopf, Inc., in 1915 with his future wife Blanche Wolf. They married in 1916, and their son Alfred “Pat” Knopf was born in 1918. Cather chose him as her publisher beginning with Youth and the Bright Medusa (1920) and One of Ours (1922), partly because she was dissatisfied with the promotion of her books by Houghton Mifflin but also because she recognized the high quality of Knopf's books, as well as what she regarded as his intelligent advertising. Knopf was noted for publishing the work of leading European and South American writers in translation, as well as original works. Knopf and Cather’s extensive correspondence testifies to their mutual professional respect and to what also became an important personal friendship.A portrait of Alfred A. Knopf taken by Carl Van Vechten on March 31, 1935The United States Library of Congress Knopf, Alfred A. (1892-1984). President of New York publisher Alfred A. Knopf, Inc. Knopf received his B.A. from Columbia University in New York City in 1912 and founded Alfred Knopf, Inc., in 1915 with his future wife Blanche Wolf. They married in 1916, and their son Alfred “Pat” Knopf was born in 1918. Cather chose him as her publisher beginning with Youth and the Bright Medusa (1920) and One of Ours (1922), partly because she was dissatisfied with the promotion of her books by Houghton Mifflin but also because she recognized the high quality of Knopf's books, as well as what she regarded as his intelligent advertising. Knopf was noted for publishing the work of leading European and South American writers in translation, as well as original works. Knopf and Cather’s extensive correspondence testifies to their mutual professional respect and to what also became an important personal friendship.No annotation is availableNo annotation is availablePortrait of Blanche Wolf Knopf by Carl Van VechtenPhotography by Carl Van Vechten©, The Van Vechten Trust, Beinecke Library, Yale Knopf, Blanche Wolf (1894-1966). Vice President of New York publisher Alfred Knopf, Inc. Blanche Wolf founded Alfred Knopf, Inc., in 1915 with her future husband Alfred Knopf. They married in 1916 and their son Alfred “Pat” Knopf was born in 1918. Active in the business throughout her life, Blanche Knopf recruited a number of prominent European and Latin American writers to the Knopf list (in translation) by traveling to meet them to meet them. In recognition of her work with writers such as Jean-Paul Sartre and Albert Camus, she was inducted into the French Legion of Honor in 1949. She became president of Alfred Knopf, Inc., in 1957 when her husband became chairman. Through her work in the publishing house she also promoted writers of the Harlem Renaissance such as Langston Hughes. Cather’s letters to Knopf focus primarily on business but the two also became friends.",
+          "text" : "⬩W⬩S⬩C⬩ July 31st My Dear Alfred; Because of the varying schedule of the one boat which is our only mail carrier, I got your letters of the 24th and 27th on the same day! First, regarding the Heinemann situation. I don't think their attitude very cordial or very promising, since they refuse to bind themselves to anything at all. I have made up my mind to let you go ahead with Cassell. I will have to write a letter to Evans, of course, and I will send you a copy of it. Meanwhile you may cable Salzberg to go ahead with Cassell, so far as I am concerned. The news you write me about the initial distribution of the new book is delightful, and is a great surprise to me. I still see in that book only a story to please the quiet and meditative few. As it has got beyond that circle, I can only conclude that you and Blanche, and your office, and the \"Archbishop\" of four years ago, all had a good deal to do with bringing this bashful volume out before the curtain. I think the review in the Atlantic will make up the minds of a great many people who think they are intelligent, but unguided would probably have passed this book over as a dull one. I have just finished the longest of the three stories I mean for the next volume, and have sent it down to my secretary to be typed. It will run about 23,000 words. We had spoken of \"Obscure Destinies\" as a title for that volume of three stories. Would you like \"Out West\" better? They are all western stories; one in Colorado, one in Kansas, one in Nebraska. Tell Blanche the things from Charles came when much needed—especially the garlic and tomato paste, which you can't get in Protestant Canada; and yesterday a[I] made a risotto that would make your mouth water. I can still get excellent champagne in St. John, Pol Roger 1919, that excellent year, which I couldn't get in Paris at all, nor anywhere but at Aix-les-Bains. This island is always beautiful and the weather has been so wild and dramatic that I cannot stay at a desk very long. The climate is everything else in God's world,—but is never hot or sticky. My love to you both, and my very deep gratitude to you and all your staff for the splendid way they have stood behind this book. It gives me a lighter heart for the books to come. Faithfully yours Willa Cather"
+        },
+        "highlight" : {
+          "text" : [
+            " make your mouth <em>water</em>. I can still get excellent champagne in St. John, Pol Roger 1919, that excellent"
           ]
         }
       }
@@ -1725,54 +1898,208 @@
         {
           "key_as_string" : "1896",
           "key" : -2335219200000,
-          "doc_count" : 21
+          "doc_count" : 4
+        },
+        {
+          "key_as_string" : "1920",
+          "key" : -1577923200000,
+          "doc_count" : 4
+        },
+        {
+          "key_as_string" : "1934",
+          "key" : -1136073600000,
+          "doc_count" : 4
+        },
+        {
+          "key_as_string" : "1908",
+          "key" : -1956614400000,
+          "doc_count" : 3
+        },
+        {
+          "key_as_string" : "1938",
+          "key" : -1009843200000,
+          "doc_count" : 3
+        },
+        {
+          "key_as_string" : "1942",
+          "key" : -883612800000,
+          "doc_count" : 3
+        },
+        {
+          "key_as_string" : "1916",
+          "key" : -1704153600000,
+          "doc_count" : 2
+        },
+        {
+          "key_as_string" : "1929",
+          "key" : -1293840000000,
+          "doc_count" : 2
+        },
+        {
+          "key_as_string" : "1933",
+          "key" : -1167609600000,
+          "doc_count" : 2
+        },
+        {
+          "key_as_string" : "1936",
+          "key" : -1073001600000,
+          "doc_count" : 2
+        },
+        {
+          "key_as_string" : "1941",
+          "key" : -915148800000,
+          "doc_count" : 2
         },
         {
           "key_as_string" : "1899",
           "key" : -2240524800000,
-          "doc_count" : 9
-        },
-        {
-          "key_as_string" : "1900",
-          "key" : -2208988800000,
-          "doc_count" : 9
-        },
-        {
-          "key_as_string" : "1890",
-          "key" : -2524521600000,
-          "doc_count" : 7
-        },
-        {
-          "key_as_string" : "1898",
-          "key" : -2272060800000,
-          "doc_count" : 4
-        },
-        {
-          "key_as_string" : "1891",
-          "key" : -2492985600000,
-          "doc_count" : 3
-        },
-        {
-          "key_as_string" : "1895",
-          "key" : -2366755200000,
-          "doc_count" : 2
-        },
-        {
-          "key_as_string" : "1897",
-          "key" : -2303596800000,
-          "doc_count" : 2
-        },
-        {
-          "key_as_string" : "1892",
-          "key" : -2461449600000,
           "doc_count" : 1
         },
         {
-          "key_as_string" : "1894",
-          "key" : -2398291200000,
+          "key_as_string" : "1905",
+          "key" : -2051222400000,
+          "doc_count" : 1
+        },
+        {
+          "key_as_string" : "1909",
+          "key" : -1924992000000,
+          "doc_count" : 1
+        },
+        {
+          "key_as_string" : "1911",
+          "key" : -1861920000000,
+          "doc_count" : 1
+        },
+        {
+          "key_as_string" : "1917",
+          "key" : -1672531200000,
+          "doc_count" : 1
+        },
+        {
+          "key_as_string" : "1918",
+          "key" : -1640995200000,
+          "doc_count" : 1
+        },
+        {
+          "key_as_string" : "1925",
+          "key" : -1420070400000,
+          "doc_count" : 1
+        },
+        {
+          "key_as_string" : "1930",
+          "key" : -1262304000000,
+          "doc_count" : 1
+        },
+        {
+          "key_as_string" : "1931",
+          "key" : -1230768000000,
+          "doc_count" : 1
+        },
+        {
+          "key_as_string" : "1935",
+          "key" : -1104537600000,
+          "doc_count" : 1
+        },
+        {
+          "key_as_string" : "1940",
+          "key" : -946771200000,
+          "doc_count" : 1
+        },
+        {
+          "key_as_string" : "1944",
+          "key" : -820540800000,
           "doc_count" : 1
         }
       ]
+    },
+    "person.name" : {
+      "doc_count" : 420,
+      "person.name" : {
+        "doc_count_error_upper_bound" : 3,
+        "sum_other_doc_count" : 214,
+        "buckets" : [
+          {
+            "key" : "Cather, Elsie",
+            "doc_count" : 30
+          },
+          {
+            "key" : "Cather, Mary Virginia 'Jennie' Boak",
+            "doc_count" : 22
+          },
+          {
+            "key" : "Cather, Roscoe",
+            "doc_count" : 17
+          },
+          {
+            "key" : "",
+            "doc_count" : 16
+          },
+          {
+            "key" : "Lewis, Edith",
+            "doc_count" : 16
+          },
+          {
+            "key" : "Shannon, Margaret Cather",
+            "doc_count" : 16
+          },
+          {
+            "key" : "Cather, Charles F.",
+            "doc_count" : 11
+          },
+          {
+            "key" : "Cather, Meta Schaper",
+            "doc_count" : 8
+          },
+          {
+            "key" : "Gere, Mariel",
+            "doc_count" : 8
+          },
+          {
+            "key" : "Auld, Jessica Cather",
+            "doc_count" : 7
+          },
+          {
+            "key" : "Hambourg, Isabelle McClung",
+            "doc_count" : 7
+          },
+          {
+            "key" : "Cather, Charles Douglass 'Douglass'",
+            "doc_count" : 6
+          },
+          {
+            "key" : "Greenslet, Ferris",
+            "doc_count" : 6
+          },
+          {
+            "key" : "Mellen, Mary Virginia Auld",
+            "doc_count" : 6
+          },
+          {
+            "key" : "Sherwood, Carrie Miner",
+            "doc_count" : 6
+          },
+          {
+            "key" : "Auld, William Thomas 'Tom, Will'",
+            "doc_count" : 5
+          },
+          {
+            "key" : "Brockway, Virginia Cather",
+            "doc_count" : 5
+          },
+          {
+            "key" : "Creighton, Mary Miner",
+            "doc_count" : 5
+          },
+          {
+            "key" : "Hambourg, Jan",
+            "doc_count" : 5
+          },
+          {
+            "key" : "Cather, James Donald",
+            "doc_count" : 4
+          }
+        ]
+      }
     },
     "format" : {
       "doc_count_error_upper_bound" : 0,
@@ -1780,42 +2107,9 @@
       "buckets" : [
         {
           "key" : "letter",
-          "doc_count" : 59
+          "doc_count" : 50
         }
       ]
-    },
-    "creator.name" : {
-      "doc_count" : 47,
-      "name" : {
-        "doc_count_error_upper_bound" : 0,
-        "sum_other_doc_count" : 0,
-        "buckets" : [
-          {
-            "key" : "Cody, William Frederick, 1846-1917",
-            "doc_count" : 41
-          },
-          {
-            "key" : "Holdrege, George Ward, 1847-1926",
-            "doc_count" : 2
-          },
-          {
-            "key" : "Helen Cody Wetmore",
-            "doc_count" : 1
-          },
-          {
-            "key" : "Manderson, Charles F. (Charles Frederick), 1837-1911",
-            "doc_count" : 1
-          },
-          {
-            "key" : "Morrill, Charles H., 1842 - 1928",
-            "doc_count" : 1
-          },
-          {
-            "key" : "Wharton, Anne H.",
-            "doc_count" : 1
-          }
-        ]
-      }
     }
   }
 }

--- a/test/services/search_item_req_test.rb
+++ b/test/services/search_item_req_test.rb
@@ -33,7 +33,7 @@ class SearchItemReqTest < ActiveSupport::TestCase
       "facet_sort" => "term|desc",
       "facet" => [ "creator.name" ]
     }).facets
-    assert_equal facets, {"creator.name"=>{"nested"=>{"path"=>"creator"}, "aggs"=>{"name"=>{"terms"=>{"field"=>"creator.name", "order"=>{"_term"=>"desc"}, "size"=>20}}}}}
+    assert_equal facets, {"creator.name"=>{"nested"=>{"path"=>"creator"}, "aggs"=>{"creator.name"=>{"terms"=>{"field"=>"creator.name", "order"=>{"_term"=>"desc"}, "size"=>20}}}}}
 
     # with non-array
     facets = SearchItemReq.new({ "facet" => "title" }).facets

--- a/test/services/search_item_res_test.rb
+++ b/test/services/search_item_res_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 class SearchItemResTest < ActiveSupport::TestCase
 
   def setup
+    # test json generated with
+    # items?facet[]=person.name&facet[]=format&facet[]=date.year&debug=true&q=water
     this_dir = File.dirname(__FILE__)
     file = File.read("#{this_dir}/../fixtures/es_response.json")
     @es = JSON.parse(file)
@@ -11,12 +13,12 @@ class SearchItemResTest < ActiveSupport::TestCase
   def test_combine_highlights
     hl = SearchItemRes.new(@es).combine_highlights
     first = hl.dig(0, "highlight")
-    assert_equal first, {"text"=>[" hardly know how we are going to raise the rest to pay off 10th of May pay roll— and no <em>water</em> to", " Sulphur creek3 George things are being done there badly or the <em>water</em> would be in Sulphur Creek now. The", " to let me know but they have not— I have about given up all hope of <em>water</em> ever getting to Sulphur"]}
+    assert_equal first, {"text"=>["View of the <em>water</em> from S. Lucia street in Naples. Napoli - Strada S. Lucia 35 Ediz Artistica RICTER"]}
   end
 
   def test_reformat_facets
     facets = SearchItemRes.new(@es).reformat_facets
-    assert_equal facets, {"date.year"=>{"1896"=>21, "1899"=>9, "1900"=>9, "1890"=>7, "1898"=>4, "1891"=>3, "1895"=>2, "1897"=>2, "1892"=>1, "1894"=>1}, "format"=>{"letter"=>59}, "creator.name"=>{"Cody, William Frederick, 1846-1917"=>41, "Holdrege, George Ward, 1847-1926"=>2, "Helen Cody Wetmore"=>1, "Manderson, Charles F. (Charles Frederick), 1837-1911"=>1, "Morrill, Charles H., 1842 - 1928"=>1, "Wharton, Anne H."=>1}}
+    assert_equal facets, {"date.year"=>{"1896"=>4, "1920"=>4, "1934"=>4, "1908"=>3, "1938"=>3, "1942"=>3, "1916"=>2, "1929"=>2, "1933"=>2, "1936"=>2, "1941"=>2, "1899"=>1, "1905"=>1, "1909"=>1, "1911"=>1, "1917"=>1, "1918"=>1, "1925"=>1, "1930"=>1, "1931"=>1, "1935"=>1, "1940"=>1, "1944"=>1}, "person.name"=>{"Cather, Elsie"=>30, "Cather, Mary Virginia 'Jennie' Boak"=>22, "Cather, Roscoe"=>17, ""=>16, "Lewis, Edith"=>16, "Shannon, Margaret Cather"=>16, "Cather, Charles F."=>11, "Cather, Meta Schaper"=>8, "Gere, Mariel"=>8, "Auld, Jessica Cather"=>7, "Hambourg, Isabelle McClung"=>7, "Cather, Charles Douglass 'Douglass'"=>6, "Greenslet, Ferris"=>6, "Mellen, Mary Virginia Auld"=>6, "Sherwood, Carrie Miner"=>6, "Auld, William Thomas 'Tom, Will'"=>5, "Brockway, Virginia Cather"=>5, "Creighton, Mary Miner"=>5, "Hambourg, Jan"=>5, "Cather, James Donald"=>4}, "format"=>{"letter"=>50}}
   end
 
 end


### PR DESCRIPTION
Instead of hardcoded "name" + last half of the nested fieldname,
now the api wil use the entire nested fieldname to label the aggregation bucket
Tests updated, json substantially altered due to current data in the ES
index I was using it generate it