### PR TITLE
Fix searching and faceting on multiline values

### DIFF
--- a/app/services/search_item_req.rb
+++ b/app/services/search_item_req.rb
@@ -127,7 +127,7 @@ class SearchItemReq
             #   "partition" => 0,
             #   "num_partitions" => 10
             # },
-            "field" => f,
+            "field" => f.gsub(/\r/, ""),
             "order" => { type => dir },
             "size" => size
           }
@@ -153,7 +153,7 @@ class SearchItemReq
             "path" => path,
             "query" => {
               "term" => {
-                filter[0] => filter[1]
+                filter[0] => filter[1].gsub(/\r/, "")
               }
             }
           }
@@ -199,7 +199,7 @@ class SearchItemReq
         filter_list << range
       # TRADITIONAL FILTERS
       else
-        filter_list << { "term" => { filter[0] => filter[1] } }
+        filter_list << { "term" => { filter[0] => filter[1].gsub(/\r/, "") } }
       end
     end
     return filter_list

--- a/app/services/search_item_req.rb
+++ b/app/services/search_item_req.rb
@@ -127,7 +127,7 @@ class SearchItemReq
             #   "partition" => 0,
             #   "num_partitions" => 10
             # },
-            "field" => f.gsub(/\r/, ""),
+            "field" => f,
             "order" => { type => dir },
             "size" => size
           }
@@ -153,6 +153,7 @@ class SearchItemReq
             "path" => path,
             "query" => {
               "term" => {
+                # Remove CR's added by hidden input field values with returns
                 filter[0] => filter[1].gsub(/\r/, "")
               }
             }
@@ -199,6 +200,7 @@ class SearchItemReq
         filter_list << range
       # TRADITIONAL FILTERS
       else
+        # Remove CR's added by hidden input field values with returns
         filter_list << { "term" => { filter[0] => filter[1].gsub(/\r/, "") } }
       end
     end

--- a/test/services/search_item_req_test.rb
+++ b/test/services/search_item_req_test.rb
@@ -85,6 +85,10 @@ class SearchItemReqTest < ActiveSupport::TestCase
     filters = SearchItemReq.new({ "f" => ["category|Writings", "author.name|Herriot, James"] }).filters
     assert_equal filters, [{"term"=>{"category"=>"Writings"}}, {"nested"=>{"path"=>"author", "query"=>{"term"=>{"author.name"=>"Herriot, James"}}}}]
 
+    # multiple filters, including one with CR present
+    filters = SearchItemReq.new({ "f" => ["category|Writings", "places_written_k|Jaffrey, New Hampshire, United\r\n                           States"] }).filters
+    assert_equal filters, [{"term"=>{"category"=>"Writings"}}, {"term"=>{"places_written_k"=>"Jaffrey, New Hampshire, United\n                           States"}}]
+
     # single year
     filters = SearchItemReq.new({ "f" => ["date|1900"] }).filters
     assert_equal filters, [{"range"=>{"date"=>{"gte"=>"1900-01-01", "lte"=>"1900-12-31", "format"=>"yyyy-MM-dd"}}}]
@@ -100,6 +104,10 @@ class SearchItemReqTest < ActiveSupport::TestCase
     # nested field
     filters = SearchItemReq.new({ "f" => ["creator.name|Willa, Cather"] }).filters
     assert_equal filters, [{"nested"=>{"path"=>"creator", "query"=>{"term"=>{"creator.name"=>"Willa, Cather"}}}}]
+
+    # multiple filters, including a nested field with CR present
+    filters = SearchItemReq.new({ "f" => ["category|Writings", "author.name|Herriot,\r\nJames"] }).filters
+    assert_equal filters, [{"term"=>{"category"=>"Writings"}}, {"nested"=>{"path"=>"author", "query"=>{"term"=>{"author.name"=>"Herriot,\nJames"}}}}]
 
     # dynamic field
     filters = SearchItemReq.new({ "f" => ["publication_d|1900"] }).filters


### PR DESCRIPTION
Remove the `%0D` in the API requests for facets and filters.
Fixes #81 
However, I'm concerned that this may potentially break other queries if we want to allow searches trying to match values with CRs, perhaps via `<textarea>` inputs for API search. We aren't using any currently that I'm aware of. None of the current facet URLs in Cather Letters have `%0D` in them, so this approach seems safe at the moment.
@jduss4 is more familiar with this repository and may have other ideas how to implement this, perhaps making its behavior with Orchid less complicated. I realize now that I didn't add comments, so we'll want to add some information in the code too.