### PR TITLE
adds multivalued and nested support to sorting

### DIFF
--- a/app/services/search_item_req.rb
+++ b/app/services/search_item_req.rb
@@ -248,7 +248,26 @@ class SearchItemReq
       if dir.blank?
         dir = term == "relevancy" ? "desc" : "asc"
       end
-      sort_obj << { term => dir }
+      # instructions for multivalued field sorting
+      mode = dir == "desc" ? "max" : "min"
+      # default to sorting missing values last, this may
+      # be added as a configurable parameter later
+      missing = "_last"
+
+      # nested fields require different sorting setup
+      # note: does not support nested fields inside of nested fields
+      sort_setting = {
+        term => {
+          "order" => dir,
+          "mode" => mode,
+          "missing" => missing
+        }
+      }
+      if term.include?(".")
+        path = term.split(".").first
+        sort_setting[term]["nested"] = { "path" => path }
+      end
+      sort_obj << sort_setting
     end
 
     return sort_obj


### PR DESCRIPTION
nested fields can now be sorted (eg: creator.name)
multivalued fields sorting:  if sort ascending use min value, if sort descending use max value in field
missing fields for specified sort always sorted last

Reference used: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html

Tested against Whitman development index with nested, multivalued field, and with field which contains both multiple values (array) and single values in it to make sure sort was working in a reliable way

Closes https://github.com/CDRH/api/issues/34 unless if there are further concerns about automatically sorting nested fields by min / max